### PR TITLE
Fix the patron being set on race change

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -295,7 +295,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	if(virtue_origin.uniquefaith)
 		selected_patron = GLOB.patronlist[virtue_origin.uniquefaith[1].godhead]
 	else
-		selected_patron = /datum/patron/divine/astrata
+		selected_patron = GLOB.patronlist[/datum/patron/divine/astrata]
 
 #define APPEARANCE_CATEGORY_COLUMN "<td valign='top' width='14%'>"
 #define MAX_MUTANT_ROWS 4


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Currently, when changing race, the patron is set to the path to the astrata datum. The check that uses this (in line 449 of new_player.dm) was not interpreting this path as expected. This resulted in any patron locked role showing as unavailable upon changing race. 

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
