### PR TITLE
Gives Druid and Dendorite LE Alchemy Trait

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -82,6 +82,7 @@
 	//	H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE) LE already has master farming for some reason? I'm not going to add to it.
 		H.adjust_skillrank_up_to(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)
 		H.grant_language(/datum/language/beast) //dendor antags can talk to WWs and druids
+		ADD_TRAIT(H, TRAIT_TALENTED_ALCHEMIST, TRAIT_GENERIC) // makes sense for a wild dendorite to know herbal knowledge and alchemy.
 	if(H.patron?.type == /datum/patron/divine/noc)
 		H.adjust_skillrank_up_to(/datum/skill/misc/reading, SKILL_LEVEL_JOURNEYMAN, TRUE) // Really good at reading... almost actually useful for LE.
 		H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, SKILL_LEVEL_EXPERT, TRUE) 

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -30,7 +30,7 @@
 		/datum/virtue/combat/crimson_curse,
 	)
 
-	job_traits = list(TRAIT_SEEDKNOW, TRAIT_OUTDOORSMAN, TRAIT_RITUALIST, TRAIT_CLERGY, TRAIT_WOODWALKER)
+	job_traits = list(TRAIT_SEEDKNOW, TRAIT_OUTDOORSMAN, TRAIT_RITUALIST, TRAIT_CLERGY, TRAIT_WOODWALKER, TRAIT_TALENTED_ALCHEMIST)
 
 	advclass_cat_rolls = list(CTAG_DRUID = 2)
 	job_subclasses = list(


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Few line changes that give Druids and Dendorite LE's the trait to grind alchemy again.

## Testing Evidence

<img width="457" height="501" alt="6PEIMnr" src="https://github.com/user-attachments/assets/1f6c7606-e5f5-4ed7-bf96-25d393e73463" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

SR nerfed alchemy by giving select classes and patron followers a trait to grind the skill so it wasn't as widely accessible or easily trainable. Dendorites were overlooked despite making complete sense, as herbs and plants are intertwined to nature and by that, Dendor. Combined with the already ample starting alchemy skill, I think it's fine to allow these roles the option of training this skill further again.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
