### PR TITLE
Made it so Master and Legendary Climbing gave you fall damage protection like in Vanderlin

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -318,7 +318,7 @@
 	if(isliving(A))
 		var/mob/living/O = A
 		var/dex_save = O.get_skill_level(/datum/skill/misc/climbing)
-		if( levels <= 3 && (dex_save >= 5 || HAS_TRAIT(A, TRAIT_NOFALLDAMAGE1) || HAS_TRAIT(A, TRAIT_NOFALLDAMAGE2)))
+		if( levels <= 3 && (dex_save >= 6 || HAS_TRAIT(A, TRAIT_NOFALLDAMAGE1) || HAS_TRAIT(A, TRAIT_NOFALLDAMAGE2)))
 			if(O.m_intent != MOVE_INTENT_SNEAK) // If we're sneaking, don't show a message to anybody, shhh!
 				O.visible_message("<span class='danger'>[A] gracefully lands on top of [src]!</span>")
 		else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -51,21 +51,19 @@
 			return
 	var/dex_save = src.get_skill_level(/datum/skill/misc/climbing)
 	var/sneak_fall = FALSE // If we're sneaking, don't announce it to our surroundings
-	if(dex_save >= 5) // Master climbers can fall down 2 levels without hurting themselves
+	if(dex_save >= 6) // LEGENDARY climbers can fall down 2 levels without hurting themselves
 		if(levels <= 3)
 			to_chat(src, "<span class='info'>My dexterity allowed me to land on my feet unscathed!</span>")
 			if(src.m_intent != MOVE_INTENT_SNEAK) // If we're sneaking, don't make a sound
-				sneak_fall = TRUE
 				playsound(src.loc, 'sound/foley/bodyfall (1).ogg', 100, FALSE)
 			return
 	var/points
 	for(var/i in 2 to levels)
 		i++
 		points += "!"
-	if(!sneak_fall)
-		visible_message("<span class='danger'>[src] falls down[points]</span>", \
-						"<span class='danger'>I fall down[points]</span>")
 		playsound(src.loc, 'sound/foley/zfall.ogg', 100, FALSE)
+	visible_message("<span class='danger'>[src] falls down[points]</span>", \
+					"<span class='danger'>I fall down[points]</span>")
 	if(!isgroundlessturf(T))
 		ZImpactDamage(T, levels)
 		record_round_statistic(STATS_MOAT_FALLERS)


### PR DESCRIPTION
## About The Pull Request

Made it so like in Vanderlin, Master and Legendary Climbing gave you partial fall damage protection up to 2 z-levels above ground.

This is good cause it means you can do sick ass aura falls and land UNSCATCHED AND STOIC!!!

Also it gives more advantage to more dextrous classes

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="563" height="135" alt="image" src="https://github.com/user-attachments/assets/5a755aab-4475-4a76-9093-4b24caba7496" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Ports nice features from Vanderlin

Ensures people can aura farm (VERY important)

Gives mobility to Dexterous classes

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
