### PR TITLE
Fix looping sounds persisting forever when multiple players are in range

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -292,8 +292,15 @@
 						return TRUE // Necessary to prevent sounds from double updating... why wasn't this here before?
 		else
 			D.thingshearing += our_ref
+			// playsound() reuses one sound/S object across all playsound_local calls,
+			// mutating S.channel per mob. Storing a reference to the shared S means
+			// every mob ends up with the last mob's channel in played_loops["SOUND"],
+			// so stop_sound_channel() sends to the wrong channel and the sound loops forever.
+			// We copy only the fields needed for stop/mute/volume operations.
+			var/sound/S_stored = sound(S.file)
+			S_stored.channel = S.channel
 			client.played_loops[D] = list()
-			client.played_loops[D]["SOUND"] = S
+			client.played_loops[D]["SOUND"] = S_stored
 			client.played_loops[D]["VOL"] = S.volume
 			client.played_loops[D]["MUTESTATUS"] = null
 			client.played_loops[D]["PIXEL_X"] = client.pixel_x


### PR DESCRIPTION
playsound() creates a single sound/S object and passes it by reference to every playsound_local() call. Each call sets S.channel to that mob's assigned channel, then stores the shared reference in played_loops["SOUND"]. After the loop, S.channel holds the last mob's channel, so all mobs end up with the wrong channel in their stored sound datum. stop_sound_channel() then sends the stop signal to the wrong channel and the sound never stops.

Fix: snapshot the channel into a per-mob sound copy at the point of storage so each client's played_loops["SOUND"].channel is stable and correct.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

good, also yeah I am officially a vibe coder 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
