### PR TITLE
Unapologetic harpy flight buffs

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -202,10 +202,10 @@
 				var/athletics_skill = max(C.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
 				var/stamina_cost_final = round((10 - athletics_skill), 1)
 				var/mob/living/carbon/human/pulling = C.pulling
-				var/time_taken = 1.5 SECONDS
+				var/time_taken = 1 SECONDS
 				if(ismob(pulling))
 					stamina_cost_final *= 2 //double our stamina cost if we're pulling someone with us
-					time_taken *= 2
+					time_taken *= 1.5
 				if(do_after(C, time_taken))
 					if(ismob(C.pulling))
 						C.pulling.forceMove(turf_above)
@@ -253,10 +253,9 @@
 				var/athletics_skill = max(C.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
 				var/stamina_cost_final = round((10 - athletics_skill), 1)
 				var/mob/living/carbon/human/pulling = C.pulling
-				var/time_taken = 1.5 SECONDS
+				var/time_taken = 0.5 SECONDS
 				if(ismob(pulling))
 					stamina_cost_final *= 2 //double our stamina cost if we're pulling someone with us
-					time_taken *= 2
 				if(do_after(C, time_taken))
 					if(ismob(C.pulling))
 						C.pulling.forceMove(turf_below)

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -204,8 +204,8 @@
 				var/mob/living/carbon/human/pulling = C.pulling
 				var/time_taken = 1 SECONDS
 				if(ismob(pulling))
-					stamina_cost_final *= 2 //double our stamina cost if we're pulling someone with us
-					time_taken *= 1.5
+					stamina_cost_final *= 1.5 //higher stamina cost if we're pulling someone with us
+					time_taken *= 2.5
 				if(do_after(C, time_taken))
 					if(ismob(C.pulling))
 						C.pulling.forceMove(turf_above)
@@ -255,7 +255,7 @@
 				var/mob/living/carbon/human/pulling = C.pulling
 				var/time_taken = 0.5 SECONDS
 				if(ismob(pulling))
-					stamina_cost_final *= 2 //double our stamina cost if we're pulling someone with us
+					stamina_cost_final *= 1.5 //Higher stamina cost if we're pulling someone with us
 				if(do_after(C, time_taken))
 					if(ismob(C.pulling))
 						C.pulling.forceMove(turf_below)

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -834,7 +834,7 @@
 	var/obj/effect/flyer_shadow/shadow
 	var/mob/living/carbon/human/harpy
 	var/mob/living/carbon/human/passenger
-	var/stamcost = 9
+	var/stamcost = 8
 	var/obj/item/organ/wings/harpy/harpy_wings
 
 /datum/status_effect/debuff/harpy_flight/on_creation(mob/living/new_owner, new_stamcost)

--- a/code/modules/surgery/organs/feature_organs/wings.dm
+++ b/code/modules/surgery/organs/feature_organs/wings.dm
@@ -99,7 +99,7 @@
 	ignore_cockblock = TRUE
 	recharge_time = 5
 	miracle = FALSE
-	var/baseline_stamina_cost = 9
+	var/baseline_stamina_cost = 8
 	var/list/swoop_sound = list(
 		'sound/foley/footsteps/flight_sounds/swooping1.ogg',
 		'sound/foley/footsteps/flight_sounds/swooping2.ogg',
@@ -118,7 +118,7 @@
 							user.Knockdown(10)
 						else
 							user.visible_message(span_notice("[user] prepares to take flight."))
-							if(do_after(user, 3 SECONDS))
+							if(do_after(user, 2 SECONDS))
 								var/athletics_skill = max(user.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
 								var/stamina_cost_final = round((baseline_stamina_cost - athletics_skill), 1)
 								user.apply_status_effect(/datum/status_effect/debuff/harpy_flight, stamina_cost_final)


### PR DESCRIPTION
## About The Pull Request
notably reduces the time it takes a harpy to fly up with flight active.

Keeps the time to lift a mob roughly the same. We'll try and keep this high to prevent the dreaded drop-stun lock from being so easy to pull off.

dramatically reduces the time it takes a harpy to fly down

Slightly reduces the time it takes for a harpy to initiate flight

Slightly reduces most stamina costs. VERY slightly. Mainly to help with scenarios it's multiplied.

It no longer takes 2x longer to lower someone. As gravity is doing most of the work here.


<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

This is with what I would call the most ''dramatic'' example one can get out of a Adventure class. A light armor puglist amazon with the Hardy statpack. This is easily the most min-maxed example outside of a wretch one can get and forgoes having much DPS in favor of endurance for flight.


https://github.com/user-attachments/assets/bc953af2-a657-494d-8726-498ba24cef21


## Why It's Good For The Game
Harpies got nerfed into oblivion without a even a thought by Scarlet. They just cranked the numbers and called it. The nerf was not just double it was easily tripled in all aspects making their flight mechanic fairly impractical for moving around, nearly **impossible** to carry people and all around just made the mechanic so extreme that it was not particularly useful without chugging a strong stamina potion or having genuinely unbelievable stats.

Nerfed to the point of removal. Effectively. 

In this PR I hope to find that sweetspot. I've played a lot of harpy and I believe as this is should be a good middle ground. Theres still a fairly good window to stop a harpy from starting flight or stealing you.  But once flight has started they'll be gone quick.

This is still worse then they had it when harpies where first added. Though should still manage a similar feel for mobility.

Leave this TMed awhile. I'll harass some people with a few builds and see how it goes.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
