### PR TITLE
rename /wall/alt and /murderhole/alt recipes

### DIFF
--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -125,6 +125,7 @@
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/turfs/wood/wall/alt
+	name = "wall (wood, planks)" // Distinct from parent "wall (wood)" so name-keyed craftability dict doesn't collide.
 	reqs = list(/obj/item/natural/wood/plank = 2)
 
 /datum/crafting_recipe/roguetown/turfs/wood/fancy
@@ -161,6 +162,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/turfs/wood/murderhole/alt
+	name = "murder hole (wood, planks)" // Distinct from parent "murder hole (wood)" so name-keyed craftability dict doesn't collide.
 	reqs = list(/obj/item/natural/wood/plank = 2)
 
 /// STONE


### PR DESCRIPTION
Both /datum/crafting_recipe/roguetown/turfs/wood/wall and its /alt subtype shared the name "wall (wood)" (alt inherited). Same for the murderhole pair. The craftability dict in personal_crafting.ui_data is keyed by recipe name, so iteration order let the second recipe overwrite the first's craftability result. Effect: when a user had only one type of ingredient, the entry showed as ungreyed/greyed inconsistently, and a click on the wrong (duplicate-named) entry silently failed in check_contents.

Distinct names ("wall (wood, planks)" / "murder hole (wood, planks)") give each recipe its own craftability slot and let users tell them apart in the menu.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

fixing shit is good 
