### PR TITLE
warscholar Vizer bug avoidance

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -325,7 +325,7 @@
 	movement_interrupt = FALSE
 //	chargedloop = /datum/looping_sound/invokeholy
 	chargedloop = null
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross, /obj/item/clothing/mask/rogue)
+	req_items = list(/obj/item/clothing/mask/rogue)
 	sound = list('sound/magic/convergence1.ogg','sound/magic/convergence2.ogg','sound/magic/convergence3.ogg','sound/magic/convergence4.ogg')
 	invocation_type = "none"
 	associated_skill = /datum/skill/magic/holy


### PR DESCRIPTION
We gonna skip format on this one.  Its a quick  fix

Clerical psydonites get their usual spells (ENDURE/RESPITE) scaled by number and quality of equipped psycrosses.

Warscholar Vizer prior this NEEDS a psycross to cast their  unique fortify spell.

If you wear more then 1 cross some kind of error happens and the check for the cross fails. Not allowing you to cast it.

Meaning Vizers are entirely locked out of their psydonite mechanic of wearing several crosses.

The bug likely needs fixing but like. This currently the only example of it being a problem so I'm just gonna scoot around it cos I don't get why its happening.


Just full merge and trust. it's a one liner.