### PR TITLE
Disables stage 4 addiction for Emberwine

### DIFF
--- a/code/datums/sexcon/sexcon_reagents.dm
+++ b/code/datums/sexcon/sexcon_reagents.dm
@@ -19,7 +19,7 @@
 	metabolization_rate = 0.02 * REAGENTS_METABOLISM
 	overdose_threshold = 18
 	addiction_threshold = 12 //Three sips, or a full goblet if properly mixed with two other reagents to hide the taste.
-	addiction_permanent = TRUE
+	addiction_permanent = FALSE
 	color = "#721a46"
 
 /datum/reagent/consumable/ethanol/beer/emberwine/on_mob_metabolize(mob/living/carbon/human/C)
@@ -102,7 +102,7 @@
 			H.charflaw = new /datum/charflaw/addiction/lovefiend(H)
 	return
 
-/datum/reagent/consumable/ethanol/beer/emberwine/addiction_act_stage4(mob/living/carbon/human/C)
+#/datum/reagent/consumable/ethanol/beer/emberwine/addiction_act_stage4(mob/living/carbon/human/C)
 	var/datum/sex_controller/S = C.sexcon
 	SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/withdrawal_severe, name) //Not critical because they'll already be getting blueballed.
 	if(!S.arousal_frozen)


### PR DESCRIPTION
Dealing with this is quite miserable since it's essentially chemical castration requiring painful admin intervention to rectify. This should hopefully just disable the fourth stage temporarily until it gets fixed later on. Additionally the addiction was flagged to now be non-permanent; I guess. Should help out.

## About The Pull Request

- Disable the fourth stage of Emberwine addiction which is kind of buggy.
- Removes "permanent" addiction flag by just setting it to false.

## Testing Evidence

It's a commented line but I'd be willing to test it in-game or my own on localhost if it's necessary.

## Why It's Good For The Game

Would be less painful for admins to deal with this when experimenting with sexcon; and less punishing to players who would require admin intervention for such.