### PR TITLE
gnoll polish: 5-min armor regen, examine readout, broken-armor fix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -595,6 +595,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			inspec += "[percent]% ([floor(eff_currint)])"
 			if(force >= 5) // Durability is rather obvious for non-weapons
 				inspec += " <span class='info'><a href='?src=[REF(src)];explaindurability=1'>{?}</a></span>"
+			var/extra_durability_info = get_inspect_durability_extra()
+			if(extra_durability_info)
+				inspec += extra_durability_info
 		if(istype(src, /obj/item/clothing))	//awful
 			var/obj/item/clothing/C = src
 			var/str
@@ -1169,6 +1172,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/on_grind()
 
 /obj/item/proc/on_juice()
+
+/// Hook for the appraisal tooltip — appended right after the DURABILITY line.
+/// Return a string (with leading "\n") to add a row, or null to skip.
+/obj/item/proc/get_inspect_durability_extra()
+	return null
 
 /obj/item/proc/get_force_string(var/force)
 	switch(force)

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
@@ -13,7 +13,11 @@
 	sewrepair = FALSE
 	max_integrity = 475
 	item_flags = DROPDEL
-	repair_time = 14 SECONDS
+	// 5 minutes of zero damage before regen kicks in — every hit (any damage
+	// amount) resets the timer via /armor/regenerating/take_damage. Once the
+	// threshold passes the existing process() loop ticks `repair_amount` per
+	// SSobj cycle until full.
+	repair_time = 5 MINUTES
 
 /datum/antagonist/gnoll
 	name = "Gnoll"

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
@@ -13,11 +13,11 @@
 	sewrepair = FALSE
 	max_integrity = 475
 	item_flags = DROPDEL
-	// 5 minutes of zero damage before regen kicks in — every hit (any damage
-	// amount) resets the timer via /armor/regenerating/take_damage. Once the
-	// threshold passes the existing process() loop ticks `repair_amount` per
-	// SSobj cycle until full.
+	// 5 minutes of zero damage before regen kicks in. Trivial damage
+	// (post-armor < 5) ticks integrity but does NOT reset the timer, so
+	// brushing past a thorn bush won't keep a gnoll's skin from mending.
 	repair_time = 5 MINUTES
+	min_damage_to_reset = 5
 
 /datum/antagonist/gnoll
 	name = "Gnoll"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -330,11 +330,11 @@
 */
 
 /obj/item/clothing/obj_break(damage_flag)
+	// getList() returns a fresh list, not a ref to the armor datum — mutating
+	// it was a no-op, leaving broken armor still protecting the wearer.
+	// Swap in a zeroed datum so getRating() returns 0 for every flag.
 	original_armor = armor
-	var/list/armorlist = armor.getList()
-	for(var/x in armorlist)
-		if(armorlist[x] > 0)
-			armorlist[x] = 0
+	armor = getArmor(0, 0, 0, 0, 0, 0, 0)
 	..()
 
 /obj/item/clothing/obj_fix()

--- a/code/modules/clothing/rogueclothes/armor_regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor_regenerating.dm
@@ -24,6 +24,10 @@
 	var/last_damage_time = 0
 	/// TRUE between "begin" and "end" messages — gates which message fires each tick.
 	var/is_regenerating = FALSE
+	/// Post-armor damage below this threshold is ignored for the regen timer
+	/// (integrity still ticks down, but `last_damage_time` is not bumped and
+	/// any in-flight mend is not interrupted). 0 = preserve original behavior.
+	var/min_damage_to_reset = 0
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/Initialize(mapload)
 	. = ..()
@@ -34,12 +38,27 @@
 	. = ..()
 	if(!damage_amount)
 		return
+	if(obj_integrity < max_integrity)
+		START_PROCESSING(SSobj, src)
+	// Sub-threshold damage (thorns, scrapes) still ticks integrity down but
+	// does NOT reset the regen timer or interrupt an in-flight mend. `.` is
+	// the post-armor damage from the parent; when armor is broken our
+	// obj_break zeroes the datum so `.` equals raw input, matching the
+	// "no armor → use raw incoming" intent.
+	if(min_damage_to_reset > 0 && . < min_damage_to_reset)
+		return
 	last_damage_time = world.time
 	if(is_regenerating && ismob(loc))
 		to_chat(loc, span_notice(repairmsg_stop))
 	is_regenerating = FALSE
-	if(obj_integrity < max_integrity)
-		START_PROCESSING(SSobj, src)
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/get_inspect_durability_extra()
+	if(obj_integrity >= max_integrity)
+		return null
+	var/time_left = (last_damage_time + repair_time) - world.time
+	if(time_left <= 0)
+		return "\n<b>REGENERATING</b>"
+	return "\n<b>REGENERATES IN:</b> [round(time_left / 10)]s"
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/process()
 	if(obj_integrity >= max_integrity)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_knight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_knight.dm
@@ -37,4 +37,4 @@
 	icon_state = "knight"
 	max_integrity = 800
 	armor = ARMOR_GNOLL_STRONG
-	repair_time = 32 SECONDS
+	// Inherits the 5-minute repair_time from the gnoll_armor base.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -420,6 +420,24 @@
 		if(s_store && !(SLOT_S_STORE in obscured))
 			if(is_normal || is_smart)
 				. += "[m1] carrying [s_store.get_examine_string(user)] on [m2] [wear_armor.name]."
+
+	// Gnoll pelt — surfaces the regenerating gnoll skin armor when worn.
+	// Always shows the name + integrity to any examiner (mirrors wear_shirt,
+	// not wear_armor: an average examiner still gets the verbal damage
+	// description, smart examiners get the exact %). Stupid examiners see a
+	// degraded placeholder instead of the actual pelt name.
+	if(istype(skin_armor, /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor))
+		var/obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/pelt = skin_armor
+		var/pelt_line
+		if(is_stupid)
+			pelt_line = "[m3] some matted fur and scarred hide!"
+		else
+			pelt_line = "[m3] [pelt.name]."
+			var/integrity_str = pelt.integrity_check(is_smart)
+			if(integrity_str)
+				pelt_line += " [integrity_str]"
+		. += pelt_line
+
 	//back
 //	if(back)
 //		. += "[m3] [back.get_examine_string(user)] on [m2] back."


### PR DESCRIPTION
Three changes from gnoll testing:

- Gnoll skin `repair_time` raised to 5 minutes (from 14s base / 32s knight override). Any hit resets the timer; once it passes, the existing process loop ticks `repair_amount` per SSobj cycle until full.

- Examiners see the worn gnoll pelt on a human, mirroring the wear_shirt pattern: name + verbal integrity description for average examiners, exact percentage for smart examiners, degraded "matted fur" placeholder for stupid examiners.

- `/obj/item/clothing/obj_break` no longer leaves broken armor still protecting the wearer. The old code mutated the throwaway list returned by `armor.getList()` instead of the armor datum itself, so broken armor kept its full ratings until destroyed. Now swaps in a zeroed datum; `obj_fix` already restores via `original_armor`. Affects all clothing, not just gnoll skin.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
