### PR TITLE
Add sanity check when splitting coins

### DIFF
--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -126,6 +126,8 @@
 		if(quantity == 1)
 			amt_text = ""
 		var/amount = input(user, "How many [plural_name] to split?[amt_text]", null, round(quantity/2, 1)) as null|num
+		if(QDELETED(user) || QDELETED(src) || !user.Adjacent(src)) // if coins were consumed/user was deleted/moved away, don't split
+			return
 		amount = clamp(amount, 0, quantity)
 		amount = round(amount, 1) // no taking non-integer coins
 		if(!amount)


### PR DESCRIPTION
## About The Pull Request
Adds a sanity check when splitting coins, preventing duping.

Thanks to Viertel for this fix.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9cb1e21d-ef82-4f67-8687-0ff988287ffd" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/03d3e8ff-e7e8-42d5-96e7-50c3add3b74f" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/224c1ed9-6901-4080-b7e9-d051ee25b14d" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bug and exploit fix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
