### PR TITLE
Let races with natural skin armor cast the arcyne ward

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -824,7 +824,7 @@
 /mob/living/carbon/human/proc/get_best_worn_armor(def_zone, d_type)
 	var/protection = 0
 	var/obj/item/clothing/used
-	var/list/body_parts = list(skin_armor, head, wear_mask, wear_wrists, gloves, wear_neck, cloak, wear_armor, wear_shirt, shoes, wear_pants, backr, backl, belt, s_store, glasses, ears, wear_ring) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
+	var/list/body_parts = list(skin_armor, arcyne_ward_armor, head, wear_mask, wear_wrists, gloves, wear_neck, cloak, wear_armor, wear_shirt, shoes, wear_pants, backr, backl, belt, s_store, glasses, ears, wear_ring) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
 	for(var/bp in body_parts)
 		if(!bp)
 			continue

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -56,6 +56,9 @@
 
 	//Equipment slots
 	var/obj/item/clothing/skin_armor = null
+	//Magi2 arcyne ward sits here, separate from skin_armor, so natural racial armor (harpy/lamia/drider
+	//scales) keeps its own slot and layers underneath the ward instead of blocking it.
+	var/obj/item/clothing/arcyne_ward_armor = null
 	var/obj/item/clothing/wear_armor = null
 	var/obj/item/clothing/wear_pants = null
 	var/obj/item/belt = null

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -267,7 +267,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 
 			dat += "<td style='width:33%;text-align:left;vertical-align: text-top'>"
 			var/list/damtypes = list("blunt","slash","stab","piercing")
-			var/list/body_parts = list(skin_armor, head, wear_mask, wear_wrists, gloves, wear_neck, cloak, wear_armor, wear_shirt, shoes, wear_pants, backr, backl, belt, s_store, glasses, ears, wear_ring)
+			var/list/body_parts = list(skin_armor, arcyne_ward_armor, head, wear_mask, wear_wrists, gloves, wear_neck, cloak, wear_armor, wear_shirt, shoes, wear_pants, backr, backl, belt, s_store, glasses, ears, wear_ring)
 			var/list/coverage_exposed = list(READABLE_ZONE_HEAD, READABLE_ZONE_CHEST, READABLE_ZONE_ARMS, READABLE_ZONE_L_ARM, READABLE_ZONE_R_ARM, READABLE_ZONE_LEGS, READABLE_ZONE_L_LEG, READABLE_ZONE_R_LEG, READABLE_ZONE_NOSE, READABLE_ZONE_MOUTH, READABLE_ZONE_EYES, READABLE_ZONE_NECK, READABLE_ZONE_VITALS, READABLE_ZONE_GROIN, READABLE_ZONE_HANDS, READABLE_ZONE_L_HAND, READABLE_ZONE_R_HAND, READABLE_ZONE_FEET, READABLE_ZONE_L_FOOT, READABLE_ZONE_R_FOOT)
 			var/list/coverage = list()	//All of the covered areas
 			var/list/blunt_max = list()	//Highest armor prot values

--- a/modular_azurepeak/code/modules/spells/magi2/spells/arcyne_ward/conjure.dm
+++ b/modular_azurepeak/code/modules/spells/magi2/spells/arcyne_ward/conjure.dm
@@ -94,13 +94,12 @@
 		StartCooldown(adjusted_cooldown)
 		return TRUE
 
-	// Defensive: don't overwrite an existing skin_armor that isn't ours, and don't
-	// let a lower-tier ward downgrade a higher-tier one (matches upstream tier check).
-	if(H.skin_armor)
-		if(!istype(H.skin_armor, /obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2))
-			to_chat(owner, span_warning("Something else already protects my skin!"))
-			return FALSE
-		var/obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2/existing = H.skin_armor
+	// The ward lives in its own slot (arcyne_ward_armor), NOT skin_armor — so natural racial armor
+	// (harpy/lamia/drider scales) stays in skin_armor and layers underneath. get_best_worn_armor picks
+	// the strongest item per zone, so the scales keep their zones and the ward covers everything else.
+	// Only block on a lower-tier ward trying to downgrade a stronger existing one.
+	if(H.arcyne_ward_armor && !QDELETED(H.arcyne_ward_armor))
+		var/obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2/existing = H.arcyne_ward_armor
 		if(existing.arcyne_armor_tier > initial(ward_type:arcyne_armor_tier))
 			to_chat(owner, span_warning("A stronger ward already protects me!"))
 			return FALSE
@@ -111,7 +110,7 @@
 	// Conjure path — wear ward, calculate coverage once.
 	owner.visible_message(span_notice("An arcyne ward shimmers into existence around [owner]!"))
 	conjured_ward = new ward_type(H)
-	H.skin_armor = conjured_ward
+	H.arcyne_ward_armor = conjured_ward
 	conjured_ward.setup_ward(H)
 	conjured_ward.linked_spell = src
 	// Conjure starts no cooldown — the button stays available so the player can dismiss
@@ -128,7 +127,8 @@
 // ---- The ward item ----
 // Inherits from /obj/item/clothing/suit/roguetown/armor (skipping Azure-Peak's /manual
 // subtype which doesn't exist in ES). The ward is invisible (icon_state = null), sits
-// in the H.skin_armor slot, and dynamically gap-fills around the player's other armor.
+// in the H.arcyne_ward_armor slot (separate from skin_armor so racial scales layer under it), and
+// dynamically gap-fills around the player's other armor.
 
 /obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2
 	name = "arcyne ward"
@@ -231,8 +231,8 @@
 /obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2/proc/cleanup_ward()
 	if(ward_owner)
 		ward_owner.remove_filter(ARCYNE_WARD_FILTER)
-		if(ward_owner.skin_armor == src)
-			ward_owner.skin_armor = null
+		if(ward_owner.arcyne_ward_armor == src)
+			ward_owner.arcyne_ward_armor = null
 		ward_owner = null
 	if(linked_spell)
 		// Break (not dismiss) = full cooldown; dismiss handles its own proportional refund.

--- a/modular_azurepeak/code/modules/spells/magi2/spells/battlewardry/bestow_ward.dm
+++ b/modular_azurepeak/code/modules/spells/magi2/spells/battlewardry/bestow_ward.dm
@@ -52,12 +52,11 @@
 		to_chat(caster, span_warning("I cannot bestow a ward upon myself."))
 		return FALSE
 
+	// Ward goes in its own arcyne_ward_armor slot (separate from skin_armor), so a target's natural
+	// racial armor no longer blocks it — only a stronger existing ward does.
 	var/refreshing = FALSE
-	if(target.skin_armor)
-		if(!istype(target.skin_armor, /obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2))
-			to_chat(caster, span_warning("[target] is already protected by something beyond my power to overcome."))
-			return FALSE
-		var/obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2/existing = target.skin_armor
+	if(target.arcyne_ward_armor && !QDELETED(target.arcyne_ward_armor))
+		var/obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2/existing = target.arcyne_ward_armor
 		if(existing.arcyne_armor_tier > ARCYNE_WARD_TIER_OTHER)
 			to_chat(caster, span_warning("[target] already bears a ward of greater strength."))
 			return FALSE
@@ -65,7 +64,7 @@
 		qdel(existing)
 
 	var/obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2/bestowed/ward = new ward_type(target)
-	target.skin_armor = ward
+	target.arcyne_ward_armor = ward
 	ward.setup_ward(target)
 	ward.set_duration(ward_duration)
 
@@ -120,7 +119,7 @@
 // reuses the standard /obj/item/clothing/integrity_check() flavor strings.
 /mob/living/carbon/human/examine(mob/user)
 	. = ..()
-	var/obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2/ward = skin_armor
+	var/obj/item/clothing/suit/roguetown/armor/arcyne_ward_magi2/ward = arcyne_ward_armor
 	if(istype(ward))
 		. += span_info("[user == src ? "I am" : "[p_they(TRUE)] [p_are()]"] [ward.ward_examine_phrase].")
 		var/intcheck = ward.integrity_check()


### PR DESCRIPTION
The magi2 arcyne ward stored itself in the single skin_armor slot, so harpies, lamias and driders - whose natural scales already occupy it - were blocked with 'Something else already protects my skin!'.

Give the ward its own dedicated arcyne_ward_armor slot, separate from skin_armor, and add it to the armor-consideration lists. Since get_best_worn_armor picks the strongest armor per zone, the racial scales keep their zones (legs/feet/tail) while the ward covers everything else - the ward layers on top without ever touching the natural armor, so it stays fully intact during and after the ward.

Applies to both the self-cast Conjure Arcyne Ward and Bestow Ward.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
