### PR TITLE
stone and bone weapon craft skill decrease

### DIFF
--- a/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
@@ -260,7 +260,7 @@
 		/obj/item/rogueweapon/woodstaff = 1,
 		/obj/item/natural/stone = 1,
 		)
-	craftdiff = 1
+	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/survival/stonesword
 	name = "stone sword"
@@ -271,7 +271,7 @@
 		/obj/item/natural/fibers = 1,
 		/obj/item/natural/stone = 3,
 		)
-	craftdiff = 1
+	craftdiff = 0
 
 
 /datum/crafting_recipe/roguetown/survival/woodclub
@@ -398,7 +398,7 @@
 		/obj/item/natural/bone = 2,
 		/obj/item/natural/fibers = 1,
 		)
-	craftdiff = 2
+	craftdiff = 1
 
 
 /datum/crafting_recipe/roguetown/survival/boneaxe
@@ -410,7 +410,7 @@
 		/obj/item/natural/bone = 2,
 		/obj/item/natural/fibers = 1,
 		)
-	craftdiff = 2
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/survival/woodspade
 	name = "wood spade"

--- a/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
@@ -260,7 +260,7 @@
 		/obj/item/rogueweapon/woodstaff = 1,
 		/obj/item/natural/stone = 1,
 		)
-	craftdiff = 3
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/survival/stonesword
 	name = "stone sword"
@@ -398,7 +398,7 @@
 		/obj/item/natural/bone = 2,
 		/obj/item/natural/fibers = 1,
 		)
-	craftdiff = 3
+	craftdiff = 2
 
 
 /datum/crafting_recipe/roguetown/survival/boneaxe


### PR DESCRIPTION
## About The Pull Request

stone weapons (sword,spear) down to 0 craft
bone weapons (bonespear,boneaxe) down to 1 craft

## Testing Evidence

simple number changes

## Why It's Good For The Game

bone spear and stone spear were journeyman before (psychotic)
we've established in this universe that a stone axe and stone knife are both able to be made by the dimmest of laymen (craft 0), and both sprites feature evidence of handle use
i can't see how stone spears, one of the first and easiest crafts humans figured out, is harder to make than ... uhm, most of anything in the crafting menu
bone spears i put to novice since it's stronger than stone spear and the recipe more complicated

in real life knapping and boneworking are advanced skillsets but we haven't simulated that in the gameworld, so no reason to arbitrarily strangle the two primitive spear weapons
(also makes it easier to play tribal/wild people, which i enjoy)