### PR TITLE
inverted psycross nerf

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -439,10 +439,6 @@
 	grid_width = 32
 	grid_height = 32
 
-/obj/item/clothing/neck/roguetown/zcross/iron/New(loc, ...)
-	. = ..()
-	name = pick("inverted psycross", "psycross")
-
 /obj/item/clothing/neck/roguetown/psicross/astrata
 	name = "amulet of Astrata"
 	desc = "As sure as the sun rises, tomorrow will come."


### PR DESCRIPTION
## About The Pull Request
Inverted psycrosses no longer get called a ''psycross'' 50% of the time.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Zizo clerics get access to the single most powerful offensive spell in the game apon putting this cross on their neck. At no point should it be offered any sort of ''meta protection'' your openly wearing the most blatantly heretical thing in the game.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
