### PR TITLE
Celerity level 3 grants tempo

### DIFF
--- a/code/modules/vampire_neu/clan/real_clans/eoran.dm
+++ b/code/modules/vampire_neu/clan/real_clans/eoran.dm
@@ -36,7 +36,6 @@
 
 	clane_covens = list(
 		/datum/coven/presence,
-		/datum/coven/bloodheal,
 		/datum/coven/eora
 	)
 	leader = /datum/clan_leader/eoran

--- a/code/modules/vampire_neu/covens/coven_powers/celerity.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/celerity.dm
@@ -23,6 +23,7 @@
 	if(level > 2)
 		owner.AddComponent(/datum/component/after_image)
 		playsound(owner,'sound/magic/timeforward.ogg', 40, TRUE)
+		ADD_TRAIT(owner, TRAIT_TEMPO, TRAIT_VAMPIRE)
 		owner.visible_message(
 			span_warning("[owner] starts moving at inhumen speeds, their every action a blur!"))
 		if(level > 3) // "Move faster. React in less time. Your body is under perfect control."
@@ -35,6 +36,7 @@
 	qdel(owner.GetComponent(/datum/component/after_image))
 	owner.remove_status_effect(/datum/status_effect/buff/celerity)
 	if(level > 2)
+		REMOVE_TRAIT(owner, TRAIT_TEMPO, TRAIT_VAMPIRE)
 		owner.remove_movespeed_modifier(MOVESPEED_ID_CELERITY)
 		playsound(owner,'sound/magic/timestop.ogg', 40, TRUE)
 		if(level > 3)

--- a/code/modules/vampire_neu/covens/coven_powers/celerity.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/celerity.dm
@@ -36,6 +36,9 @@
 	qdel(owner.GetComponent(/datum/component/after_image))
 	owner.remove_status_effect(/datum/status_effect/buff/celerity)
 	if(level > 2)
+		owner.remove_status_effect(/datum/status_effect/buff/tempo_one)
+		owner.remove_status_effect(/datum/status_effect/buff/tempo_two)
+		owner.remove_status_effect(/datum/status_effect/buff/tempo_three)
 		REMOVE_TRAIT(owner, TRAIT_TEMPO, TRAIT_VAMPIRE)
 		
 		owner.remove_movespeed_modifier(MOVESPEED_ID_CELERITY)

--- a/code/modules/vampire_neu/covens/coven_powers/celerity.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/celerity.dm
@@ -36,7 +36,6 @@
 	qdel(owner.GetComponent(/datum/component/after_image))
 	owner.remove_status_effect(/datum/status_effect/buff/celerity)
 	if(level > 2)
-		clear_tempo_all(owner)
 		REMOVE_TRAIT(owner, TRAIT_TEMPO, TRAIT_VAMPIRE)
 		
 		owner.remove_movespeed_modifier(MOVESPEED_ID_CELERITY)

--- a/code/modules/vampire_neu/covens/coven_powers/celerity.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/celerity.dm
@@ -36,7 +36,9 @@
 	qdel(owner.GetComponent(/datum/component/after_image))
 	owner.remove_status_effect(/datum/status_effect/buff/celerity)
 	if(level > 2)
+		clear_tempo_all(owner)
 		REMOVE_TRAIT(owner, TRAIT_TEMPO, TRAIT_VAMPIRE)
+		
 		owner.remove_movespeed_modifier(MOVESPEED_ID_CELERITY)
 		playsound(owner,'sound/magic/timestop.ogg', 40, TRUE)
 		if(level > 3)


### PR DESCRIPTION
## About The Pull Request
as the title says.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested that the spell grants/removes tempo correctly. Unfortunately though im not sure how well tempo will respond to being constantly disabled and enabled in such a fashion but we'll see how it goes on live. Mindless mobs don't trigger tempo so I can't really test it properly on my own very easily.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Celerity is REALLY bad. Like. Gosh. Awful. Idk why anyone would use it over potence or the other vampire shit. I'd been racking my brain for ideas on improving it for awhile. Suddenly this clicked into my head.

I also always wanted to see tempo in use more. This might need to be bumped to level 4 celerity. But i'd like to see it be more accessible for testing for now/see if thats needed

The Spell itself constantly goes on about ''inhuman reflexes'' and I think tempo fits very nicely into that

Lastly. I'm not firm on this being a good idea. So. We'll see how it goes. Tempo is like. Crazy good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
