### PR TITLE
Fix uncooked pumpkin pie using nonexistent icon state

### DIFF
--- a/modular/Neu_Food/code/raw/raw_pies.dm
+++ b/modular/Neu_Food/code/raw/raw_pies.dm
@@ -47,7 +47,7 @@ And I don't wanna copypaste what Vanderlin has
 	var/mutable_appearance/piebottom = mutable_appearance(icon, "pieuncooked")
 	var/mutable_appearance/roofeat = mutable_appearance(icon, "meatpie_raw")
 	var/mutable_appearance/roofish = mutable_appearance(icon, "fishpie_raw")
-	var/mutable_appearance/roofkin = mutable_appearance(icon, "pumpkinpie_raw")
+	var/mutable_appearance/roofkin = mutable_appearance(icon, "pumpkinpie")
 	if (process_step == 2 && applepie)
 		var/mutable_appearance/apple1 = mutable_appearance(icon, "fill_apple1")
 		add_overlay(apple1)
@@ -271,7 +271,6 @@ And I don't wanna copypaste what Vanderlin has
 			if(do_after(user,short_cooktime, target = src))
 				name = "uncooked pumpkin pie"
 				desc = initial(desc)
-				icon_state = "pumpkinpie_raw"
 				filling_color = "#df5c04"
 				cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/pumpkin
 				cooked_smell = /datum/pollutant/food/pumpkin_pie

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2413,6 +2413,8 @@
 #include "code\modules\spells\spell_types\trigger.dm"
 #include "code\modules\spells\spell_types\turf_teleport.dm"
 #include "code\modules\spells\spell_types\wildshape.dm"
+#include "code\modules\spells\spell_types\divine\projectiles_single\divine_blast.dm"
+#include "code\modules\spells\spell_types\divine\projectiles_single\unholy_blast.dm"
 #include "code\modules\spells\spell_types\skills\invoked_single_target\engineeranalyze.dm"
 #include "code\modules\spells\spell_types\wizard\learnspell.dm"
 #include "code\modules\spells\spell_types\wizard\spell_list.dm"
@@ -2906,6 +2908,4 @@
 #include "modular_scarletreach\code\modules\mob\living\carbon\human\voicepacks\male\tabaxi.dm"
 #include "modular_scarletreach\virtues\saddleborn.dm"
 #include "modular_stonehedge\code\modules\clothing\rogueclothes\hats.dm"
-#include "code\modules\spells\spell_types\divine\projectiles_single\divine_blast.dm"
-#include "code\modules\spells\spell_types\divine\projectiles_single\unholy_blast.dm"
 // END_INCLUDE


### PR DESCRIPTION
The overlay was referencing "pumpkinpie_raw" which doesn't exist in raw_pies.dmi; AP uses "pumpkinpie". Also removes the redundant direct icon_state assignment that was added alongside it.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
