### PR TITLE
Pop-scale Wretch and Bandit latejoin job slots

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -20,6 +20,18 @@ SUBSYSTEM_DEF(job)
 	var/overflow_role = "Fuckyou"
 	var/list/level_order = list(JP_HIGH,JP_MEDIUM,JP_LOW)
 
+	// Wretch/Bandit pop-scaling.
+	// Wretch: no slots below wretch_players_per_slot players, then +1 per that many (15/30/45...).
+	// Bandit: bandit_base_slots, +1 per bandit_players_per_extra_slot players (20/40/60...).
+	// Scales both directions, but never below currently-filled positions.
+	var/wretch_players_per_slot = 15
+	var/bandit_base_slots = 2
+	var/bandit_players_per_extra_slot = 20
+	/// job title -> list(total_positions, spawn_positions) we last applied, to detect external overrides
+	var/list/wb_last_applied = list()
+	/// job titles whose auto-scaling was disabled for the round by an external change
+	var/list/wb_scaling_disabled = list()
+
 /datum/controller/subsystem/job/Initialize(timeofday)
 	if(!occupations.len)
 		SetupOccupations()
@@ -43,6 +55,47 @@ SUBSYSTEM_DEF(job)
 		old_overflow.total_positions = initial(old_overflow.total_positions)
 		overflow_role = new_overflow_role
 		JobDebug("Overflow role set to : [new_overflow_role]")
+
+// -------- Wretch/Bandit slot scaling --------
+// First call comes from SSgamemode.pre_setup() (before jobs divide, using ready players),
+// then it requeues itself every minute for the rest of the round.
+/datum/controller/subsystem/job/proc/recheck_wretch_bandit_slots(requeue = TRUE)
+	var/pop = SSgamemode ? SSgamemode.get_correct_popcount() : 0
+	scale_wb_job("Wretch", FLOOR(pop / wretch_players_per_slot, 1), pop)
+	scale_wb_job("Bandit", bandit_base_slots + FLOOR(pop / bandit_players_per_extra_slot, 1), pop)
+	if(requeue)
+		addtimer(CALLBACK(src, PROC_REF(recheck_wretch_bandit_slots)), 1 MINUTES, TIMER_UNIQUE)
+
+/datum/controller/subsystem/job/proc/scale_wb_job(title, target_slots, pop)
+	if(wb_scaling_disabled[title])
+		return
+	var/datum/job/scaled_job = GetJob(title)
+	if(!scaled_job)
+		return
+
+	var/list/applied = wb_last_applied[title]
+	if(applied && (scaled_job.total_positions != applied[1] || scaled_job.spawn_positions != applied[2]))
+		wb_scaling_disabled[title] = TRUE
+		var/override_msg = "WRETCH/BANDIT SCALING: external change to [title] slots detected ([scaled_job.total_positions]/[scaled_job.spawn_positions] vs last applied [applied[1]]/[applied[2]]); disabling [title] auto-scaling until round restart."
+		log_game(override_msg)
+		message_admins(override_msg)
+		return
+
+	// Never pull slots out from under players already in the role
+	var/new_slots = max(target_slots, scaled_job.current_positions)
+	var/old_total = scaled_job.total_positions
+	var/old_spawn = scaled_job.spawn_positions
+	if(old_total == new_slots && old_spawn == new_slots)
+		wb_last_applied[title] = list(new_slots, new_slots)
+		return
+
+	scaled_job.total_positions = new_slots
+	scaled_job.spawn_positions = new_slots
+	wb_last_applied[title] = list(new_slots, new_slots)
+
+	var/slot_msg = "WRETCH/BANDIT SCALING: [title] slots changed from [old_total]/[old_spawn] to [new_slots]/[new_slots] (pop=[pop])."
+	log_game(slot_msg)
+	message_admins(slot_msg)
 
 /datum/controller/subsystem/job/proc/SetupOccupations(faction = "Station")
 	occupations = list()

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -20,17 +20,13 @@ SUBSYSTEM_DEF(job)
 	var/overflow_role = "Fuckyou"
 	var/list/level_order = list(JP_HIGH,JP_MEDIUM,JP_LOW)
 
-	// Wretch/Bandit pop-scaling.
-	// Wretch: no slots below wretch_players_per_slot players, then +1 per that many (15/30/45...).
-	// Bandit: bandit_base_slots, +1 per bandit_players_per_extra_slot players (20/40/60...).
-	// Scales both directions, but never below currently-filled positions.
-	var/wretch_players_per_slot = 15
-	var/bandit_base_slots = 2
-	var/bandit_players_per_extra_slot = 20
-	/// job title -> list(total_positions, spawn_positions) we last applied, to detect external overrides
-	var/list/wb_last_applied = list()
-	/// job titles whose auto-scaling was disabled for the round by an external change
-	var/list/wb_scaling_disabled = list()
+	// Shared antagonist slot pool: Ogre/Wretch/Gnoll/Bandit draw from one
+	// combined pool of slots, so taking any of them uses a slot for all four.
+	// Each job's own total_positions still caps that single role; the pool
+	// caps the combined total. Slots return when a member role's
+	// current_positions drops (e.g. job_reopens_slots_on_death).
+	var/list/shared_antag_pool = list("Ogre", "Wretch", "Gnoll", "Bandit")
+	var/shared_antag_pool_cap = 5
 
 /datum/controller/subsystem/job/Initialize(timeofday)
 	if(!occupations.len)
@@ -56,46 +52,18 @@ SUBSYSTEM_DEF(job)
 		overflow_role = new_overflow_role
 		JobDebug("Overflow role set to : [new_overflow_role]")
 
-// -------- Wretch/Bandit slot scaling --------
-// First call comes from SSgamemode.pre_setup() (before jobs divide, using ready players),
-// then it requeues itself every minute for the rest of the round.
-/datum/controller/subsystem/job/proc/recheck_wretch_bandit_slots(requeue = TRUE)
-	var/pop = SSgamemode ? SSgamemode.get_correct_popcount() : 0
-	scale_wb_job("Wretch", max(1, FLOOR(pop / wretch_players_per_slot, 1)), pop)
-	scale_wb_job("Bandit", bandit_base_slots + FLOOR(pop / bandit_players_per_extra_slot, 1), pop)
-	if(requeue)
-		addtimer(CALLBACK(src, PROC_REF(recheck_wretch_bandit_slots)), 1 MINUTES, TIMER_UNIQUE)
+// -------- Shared antagonist slot pool --------
+/// Combined filled positions across every shared_antag_pool role.
+/datum/controller/subsystem/job/proc/shared_antag_pool_used()
+	. = 0
+	for(var/title in shared_antag_pool)
+		var/datum/job/pool_job = GetJob(title)
+		if(pool_job)
+			. += pool_job.current_positions
 
-/datum/controller/subsystem/job/proc/scale_wb_job(title, target_slots, pop)
-	if(wb_scaling_disabled[title])
-		return
-	var/datum/job/scaled_job = GetJob(title)
-	if(!scaled_job)
-		return
-
-	var/list/applied = wb_last_applied[title]
-	if(applied && (scaled_job.total_positions != applied[1] || scaled_job.spawn_positions != applied[2]))
-		wb_scaling_disabled[title] = TRUE
-		var/override_msg = "WRETCH/BANDIT SCALING: external change to [title] slots detected ([scaled_job.total_positions]/[scaled_job.spawn_positions] vs last applied [applied[1]]/[applied[2]]); disabling [title] auto-scaling until round restart."
-		log_game(override_msg)
-		message_admins(override_msg)
-		return
-
-	// Never pull slots out from under players already in the role
-	var/new_slots = max(target_slots, scaled_job.current_positions)
-	var/old_total = scaled_job.total_positions
-	var/old_spawn = scaled_job.spawn_positions
-	if(old_total == new_slots && old_spawn == new_slots)
-		wb_last_applied[title] = list(new_slots, new_slots)
-		return
-
-	scaled_job.total_positions = new_slots
-	scaled_job.spawn_positions = new_slots
-	wb_last_applied[title] = list(new_slots, new_slots)
-
-	var/slot_msg = "WRETCH/BANDIT SCALING: [title] slots changed from [old_total]/[old_spawn] to [new_slots]/[new_slots] (pop=[pop])."
-	log_game(slot_msg)
-	message_admins(slot_msg)
+/// Slots still open in the shared antagonist pool.
+/datum/controller/subsystem/job/proc/shared_antag_pool_remaining()
+	return max(0, shared_antag_pool_cap - shared_antag_pool_used())
 
 /datum/controller/subsystem/job/proc/SetupOccupations(faction = "Station")
 	occupations = list()
@@ -143,6 +111,9 @@ SUBSYSTEM_DEF(job)
 		if(!job.player_old_enough(player.client))
 			return FALSE
 		if(job.required_playtime_remaining(player.client))
+			return FALSE
+		if((rank in shared_antag_pool) && !shared_antag_pool_remaining())
+			JobDebug("AR shared antag pool exhausted, Player: [player], Rank: [rank]")
 			return FALSE
 		var/position_limit = job.total_positions
 		if(!latejoin)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -61,7 +61,7 @@ SUBSYSTEM_DEF(job)
 // then it requeues itself every minute for the rest of the round.
 /datum/controller/subsystem/job/proc/recheck_wretch_bandit_slots(requeue = TRUE)
 	var/pop = SSgamemode ? SSgamemode.get_correct_popcount() : 0
-	scale_wb_job("Wretch", FLOOR(pop / wretch_players_per_slot, 1), pop)
+	scale_wb_job("Wretch", max(1, FLOOR(pop / wretch_players_per_slot, 1)), pop)
 	scale_wb_job("Bandit", bandit_base_slots + FLOOR(pop / bandit_players_per_extra_slot, 1), pop)
 	if(requeue)
 		addtimer(CALLBACK(src, PROC_REF(recheck_wretch_bandit_slots)), 1 MINUTES, TIMER_UNIQUE)

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -549,6 +549,7 @@ SUBSYSTEM_DEF(gamemode)
 
 	pick_most_influential(TRUE)
 	calculate_ready_players()
+	SSjob?.recheck_wretch_bandit_slots() // scale wretch/bandit slots to ready pop before jobs divide
 	roll_pre_setup_points()
 	//handle_pre_setup_roundstart_events()
 	return TRUE

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -549,7 +549,6 @@ SUBSYSTEM_DEF(gamemode)
 
 	pick_most_influential(TRUE)
 	calculate_ready_players()
-	SSjob?.recheck_wretch_bandit_slots() // scale wretch/bandit slots to ready pop before jobs divide
 	roll_pre_setup_points()
 	//handle_pre_setup_roundstart_events()
 	return TRUE

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -3,7 +3,7 @@
 	flag = BANDIT
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 2
+	total_positions = 2 // slots are pop-scaled at runtime by SSjob.recheck_wretch_bandit_slots() (2 base, +1 per 20 players)
 	spawn_positions = 2
 	antag_job = TRUE
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -3,8 +3,8 @@
 	flag = BANDIT
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 2 // slots are pop-scaled at runtime by SSjob.recheck_wretch_bandit_slots() (2 base, +1 per 20 players)
-	spawn_positions = 2
+	total_positions = 5 // draws from SSjob.shared_antag_pool: 5 combined slots across Ogre/Wretch/Gnoll/Bandit
+	spawn_positions = 5
 	antag_job = TRUE
 	allowed_races = RACES_ALL_KINDS
 	disallowed_races = /datum/species/ogre

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -3,8 +3,8 @@
 	flag = GNOLL
 	antag_job = TRUE
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 5 // draws from SSjob.shared_antag_pool: 5 combined slots across Ogre/Wretch/Gnoll/Bandit
+	spawn_positions = 5
 	allowed_races = RACES_ALL_KINDS // Upstream RACES_NO_CONSTRUCT absent in ES — outfit forces species swap to gnoll anyway.
 	tutorial = "You have proven yourself worthy to Graggar, and he's granted you his blessing most divine. Now you hunt for worthy opponents, seeking out those strong enough to make you bleed."
 	outfit = null

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -4,7 +4,7 @@
 	flag = WRETCH
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 2
+	total_positions = 2 // slots are pop-scaled at runtime by SSjob.recheck_wretch_bandit_slots() (0 below 15 players, +1 per 15)
 	spawn_positions = 2
 	allowed_races = RACES_ALL_KINDS
 	disallowed_races = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -4,8 +4,8 @@
 	flag = WRETCH
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 2 // slots are pop-scaled at runtime by SSjob.recheck_wretch_bandit_slots() (0 below 15 players, +1 per 15)
-	spawn_positions = 2
+	total_positions = 5 // draws from SSjob.shared_antag_pool: 5 combined slots across Ogre/Wretch/Gnoll/Bandit
+	spawn_positions = 5
 	allowed_races = RACES_ALL_KINDS
 	disallowed_races = list(
 		/datum/species/ogre

--- a/code/modules/jobs/job_types/roguetown/ogre/ogre.dm
+++ b/code/modules/jobs/job_types/roguetown/ogre/ogre.dm
@@ -15,8 +15,8 @@
 	flag = OGRE
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 5 // draws from SSjob.shared_antag_pool: 5 combined slots across Ogre/Wretch/Gnoll/Bandit
+	spawn_positions = 5
 	allowed_races = OGRE_RACE_TYPES
 	allowed_sexes = list(MALE, FEMALE)
 	tutorial = "You are a migrating ogre from Gronn or another province of the world. Only recently have ogres begun to find their way into this region, and it smells of opportunity and a good meal. From Grenzelhoft to Naledi, all know the value of an ogre, and to fear a hungry one even more"

--- a/code/modules/mob/dead/new_player/late_join_choices.dm
+++ b/code/modules/mob/dead/new_player/late_join_choices.dm
@@ -148,9 +148,14 @@ GLOBAL_LIST_EMPTY(open_late_join_choices)
 		var/unavailable_code = np.IsJobUnavailable(job_datum.title, TRUE)
 		var/is_job_available = (unavailable_code == JOB_AVAILABLE)
 		var/is_cooldown = (unavailable_code == JOB_UNAVAILABLE_JOB_COOLDOWN)
+		// Shared antag pool roles show how many slots they could actually
+		// still fill, not their nominal cap.
+		var/shown_total = job_datum.total_positions
+		if(job_datum.title in SSjob.shared_antag_pool)
+			shown_total = min(shown_total, job_datum.current_positions + SSjob.shared_antag_pool_remaining())
 		availability[job_datum.title] = list(
 			"current" = job_datum.current_positions,
-			"total" = job_datum.total_positions,
+			"total" = shown_total,
 			"prioritized" = (job_datum in SSjob.prioritized_jobs),
 			"available" = is_job_available,
 			"is_cooldown" = is_cooldown,

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -481,6 +481,8 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	if((job.same_job_respawn_delay) && (ckey in GLOB.job_respawn_delays))
 		if(world.time < GLOB.job_respawn_delays[ckey])
 			return JOB_UNAVAILABLE_JOB_COOLDOWN
+	if((job.title in SSjob.shared_antag_pool) && !SSjob.shared_antag_pool_remaining())
+		return JOB_UNAVAILABLE_SLOTFULL
 	if((job.current_positions >= job.total_positions) && job.total_positions != -1)
 		if(job.title == "Assistant")
 			if(isnum(client.player_age) && client.player_age <= 14) //Newbies can always be assistants
@@ -693,6 +695,11 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			for(var/job in available_jobs)
 				var/datum/job/job_datum = SSjob.name_occupations[job]
 				var/do_elaborate = job_datum.has_limited_subclasses()
+				// Shared antag pool roles show how many slots they could
+				// actually still fill, not their nominal cap.
+				var/shown_total = job_datum.total_positions
+				if(job_datum.title in SSjob.shared_antag_pool)
+					shown_total = min(shown_total, job_datum.current_positions + SSjob.shared_antag_pool_remaining())
 				if(job_datum)
 					var/command_bold = FALSE
 					if(job in GLOB.noble_positions)
@@ -703,7 +710,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 					if(job_datum in SSjob.prioritized_jobs)
 						dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'><span class='priority'>[used_name] ([job_datum.current_positions])</span></a>"
 					else
-						dat += "<font size = 3>[do_elaborate ? "<a href='?src=[REF(job_datum)];jobsubclassinfo=1'><b><font color = '#6b6743'>(!)</font></b></a>" : ""]<a href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'>[command_bold ? "<b>" : ""][used_name] ([job_datum.current_positions]/[job_datum.total_positions])[command_bold ? "</b>" : ""]</a></font>"
+						dat += "<font size = 3>[do_elaborate ? "<a href='?src=[REF(job_datum)];jobsubclassinfo=1'><b><font color = '#6b6743'>(!)</font></b></a>" : ""]<a href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'>[command_bold ? "<b>" : ""][used_name] ([job_datum.current_positions]/[shown_total])[command_bold ? "</b>" : ""]</a></font>"
 						dat += "<br>"
 
 			dat += "</fieldset><br>"


### PR DESCRIPTION
Wretch: 1 slots below 15 players, then +1 per 15 (15/30/45...). Bandit: 2 base slots, +1 per 20 players (20/40/60...). 



 External slot edits (admin, roundstart bandit event) disable auto-scaling for that job for the round.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
