### PR TITLE
Tier-based armor: migrate pen/DR from percentages to AP tiers

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -389,13 +389,6 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 /// Damage multiplier of silver weapons against mobs with TRAIT_SIMPLE_WOUNDS
 #define SILVER_SIMPLEMOB_DAM_MULT 2
 
-//Damage directly applied to a mob, as a percentage, if struck with blunt against armour.
-//This is to permit beating to death full plate guys with clubs. Or making the lucerne viable again.
-#define BLUNT_CHIP_MINUSCULE 0.10	//A flat 10%, meant for oddities. Staves and the like.
-#define BLUNT_CHIP_WEAK 0.20		//A flat 20%, meant for small clubs.
-#define BLUNT_CHIP_STRONG 0.30		//A flat 30%, meant for larger weapons.
-#define BLUNT_CHIP_ABSURD 0.40		//A flat 40%, meant for mauls and hammers.
-
 #define PROJ_PARRY_TIMER	0.65 SECONDS	//The time after an attack (swinging in the air counts) when a thrown item would be deflected at a higher chance.
 #define TEMPO_CULL_DELAY 	12 SECONDS	//Interval for checking our tempo lists. Only relevant to player mobs with TRAIT_TEMPO
 #define TEMPO_DELAY_ONE 30 SECONDS

--- a/code/__DEFINES/roguetown/armor_defines.dm
+++ b/code/__DEFINES/roguetown/armor_defines.dm
@@ -1,4 +1,45 @@
 /*------------------------\
+|   ARMOR RATING TIERS    | // Tier constants ported from AP. Armor VALUE defines below now use these tiers
+\------------------------*/ // (DR_* / DBLOCK_*) instead of 0-100 percentages. Integrity defines stay numeric.
+
+// Penetration tiers (0-4). Weapon attacks.
+#define PEN_NONE			0	// No penetration. Training weapons, base cuts/chops.
+#define PEN_LIGHT			1	// Falx cut, axe chop. Penetrates trash armor (NPC cloth/bad leather).
+#define PEN_MEDIUM			2	// Sword thrusts, longsword chop. Penetrates player light armor (gambeson, hardened leather).
+#define PEN_HEAVY			3	// Spear, estoc. Penetrates mail/brigandine/plate.
+#define PEN_BSTEEL			4	// Halfsword, dagger pick. Penetrates plate fully, blacksteel.
+
+// Damage Blocking tiers (0-4). Armor clothing.
+#define DBLOCK_NONE			0	// No blocking. Unarmored skin.
+#define DBLOCK_LIGHT		1	// Cloth, bad leather, NPC trash armor.
+#define DBLOCK_MEDIUM		2	// Gambeson, padded, hardened leather, studded — player light armor.
+#define DBLOCK_HEAVY		3	// Brigandine, mail, cuirass, plate.
+#define DBLOCK_BSTEEL		4	// Blacksteel, antagonist.
+
+// Damage reduction tiers (0-5). Used by blunt (absorb), fire, acid (pierce).
+// Note that blunt by default have 1.6x Integrity Multiplier.
+// Damage multiplier = 1 / (1 + 0.2 * tier)
+// Blunt: all damage absorbed by armor. Fire/Acid: reduced damage still hits HP.
+#define DR_NONE				0	// Nothing. 100% damage. EDPS: 160%
+#define DR_LIGHT			1	// Plate / Metal. 20% EHP increase. EDPS: 133%
+#define DR_MEDIUM			2	// Mail. 40% EHP increase. EDPS: 114%
+#define DR_HEAVY			3	// Bad Light Armor. 60% EHP increase. EDPS: 100%
+#define DR_SUPER			4	// Medium Light Armor. 80% EHP increase. EDPS: 89%
+#define DR_ULTRA			5	// Best quality light armor. 100% EHP increase. EDPS: 80%
+
+// Damage-type families — which resolution path each type takes in run_armor_check().
+#define ARMOR_DR_ABSORB_TYPES list("blunt")						// Armor absorbs ALL HP damage; the hit lands on integrity instead.
+#define ARMOR_DR_PIERCE_TYPES list("fire", "acid")				// DR reduces damage, but the reduced damage still reaches HP.
+#define ARMOR_DBLOCK_TYPES list("slash", "stab", "piercing")	// Weapon PEN tier vs armor DBLOCK tier.
+
+// Penetration passthrough fractions
+#define PEN_PASSTHROUGH_RATIO	0.1		// Damage through per pen "dot" (pen vs armor + relevant stat above 10). 0.1 = 10%
+#define PEN_PASSTHROUGH_PROJ_EQUAL 0.2	// Projectile, pen == armor: 20% through
+#define PEN_PASSTHROUGH_PROJ_MORE 0.8	// Projectile, pen > armor: 80% through
+#define PEN_PASSTHROUGH_CAP	8			// Max pen "dots" (pen vs armor + 1 per relevant stat above 10)
+
+
+/*------------------------\
 | ARMOR INTEGRITY DEFINES | // Use these when possible on armor to keep value consistent.
 \------------------------*/
 // Side = Non-chest armor integrity
@@ -69,86 +110,86 @@
 
 
 /*--------------------\
-| ARMOR VALUE DEFINES |
+| ARMOR VALUE DEFINES | // Tier values. blunt/fire/acid = DR_* ; slash/stab/piercing = DBLOCK_*
 \--------------------*/
 // Misc defines. These are here just in case. Inherited by their relevant subtypes.
-#define ARMOR_MACHINERY list("blunt" = 25, "slash" = 25, "stab" = 25,  "piercing" = 10, "fire" = 50, "acid" = 70)
-#define ARMOR_STRUCTURE list("blunt" = 0, "slash" = 0, "stab" = 0, "piercing" = 0, "fire" = 50, "acid" = 50)
-#define ARMOR_DISPLAYCASE list("blunt" = 30, "slash" = 30, "stab" = 30,  "piercing" = 0, "fire" = 70, "acid" = 100)
-#define ARMOR_CLOSET list("blunt" = 20, "slash" = 10, "stab" = 15, "piercing" = 10, "fire" = 70, "acid" = 60)
-#define ARMOR_BLACKBAG list("blunt" = 100, "slash" = 100, "stab" = 100, "piercing" = 100, "fire" = 75, "acid" = 100)
+#define ARMOR_MACHINERY list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_HEAVY, "acid" = DR_SUPER)
+#define ARMOR_STRUCTURE list("blunt" = DR_NONE, "slash" = DBLOCK_NONE, "stab" = DBLOCK_NONE, "piercing" = DBLOCK_NONE, "fire" = DR_HEAVY, "acid" = DR_HEAVY)
+#define ARMOR_DISPLAYCASE list("blunt" = DR_MEDIUM, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_NONE, "fire" = DR_SUPER, "acid" = DR_ULTRA)
+#define ARMOR_CLOSET list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_SUPER, "acid" = DR_HEAVY)
+#define ARMOR_BLACKBAG list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_SUPER, "acid" = DR_ULTRA)
 
 // Light AC | Chest
-#define ARMOR_CLOTHING list("blunt" = 0, "slash" = 10, "stab" = 20, "piercing" = 0, "fire" = 0, "acid" = 0)
-#define ARMOR_PADDED_GOOD list("blunt" = 80, "slash" = 50, "stab" = 50, "piercing" = 80, "fire" = 0, "acid" = 0)
-#define ARMOR_PADDED list("blunt" = 60, "slash" = 40, "stab" = 30, "piercing" = 50, "fire" = 0, "acid" = 0)
-#define ARMOR_PADDED_BAD list("blunt" = 40, "slash" = 30, "stab" = 20, "piercing" = 40, "fire" = 0, "acid" = 0)
-#define ARMOR_LIGHTCUIRASS list("blunt" = 30, "slash" = 70, "stab" = 70, "piercing" = 30, "fire" = 0, "acid" = 0)
+#define ARMOR_CLOTHING list("blunt" = DR_NONE, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_NONE, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_PADDED_GOOD list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_HEAVY, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_PADDED list("blunt" = DR_HEAVY, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_PADDED_BAD list("blunt" = DR_MEDIUM, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_LIGHTCUIRASS list("blunt" = DR_MEDIUM, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 
-#define ARMOR_LEATHER list("blunt" = 60, "slash" = 50, "stab" = 40, "piercing" = 20, "fire" = 0, "acid" = 0)
-#define ARMOR_LEATHER_GOOD list("blunt" = 100, "slash" = 70, "stab" = 50, "piercing" = 30, "fire" = 0, "acid" = 0)
-#define ARMOR_LEATHER_STUDDED list("blunt" = 80, "slash" = 80, "stab" = 60, "piercing" = 20, "fire" = 0, "acid" = 0)
+#define ARMOR_LEATHER list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_LEATHER_GOOD list("blunt" = DR_ULTRA, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_LEATHER_STUDDED list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 
 // Medium AC | Chest
-#define ARMOR_CUIRASS list("blunt" = 40, "slash" = 100, "stab" = 80, "piercing" = 60, "fire" = 0, "acid" = 0)
-#define ARMOR_MAILLE list("blunt" = 40, "slash" = 100, "stab" = 80, "piercing" = 50, "fire" = 0, "acid" = 0)
+#define ARMOR_CUIRASS list("blunt" = DR_MEDIUM, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_MAILLE list("blunt" = DR_MEDIUM, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
 
 // Heavy AC | Chest
-#define ARMOR_PLATE list("blunt" = 10, "slash" = 100, "stab" = 80, "piercing" = 75, "fire" = 0, "acid" = 0)
-#define ARMOR_PLATE_GOOD list("blunt" = 50, "slash" = 100, "stab" = 80, "piercing" = 80, "fire" = 0, "acid" = 0)
-#define ARMOR_PLATE_BSTEEL list("blunt" = 80, "slash" = 100, "stab" = 90, "piercing" = 80, "fire" = 0, "acid" = 0) // It's EVIL. OH GOD.
+#define ARMOR_PLATE list("blunt" = DR_LIGHT, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_PLATE_GOOD list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_PLATE_BSTEEL list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_LIGHT, "acid" = DR_NONE) // It's EVIL. OH GOD.
 
 // Boot Armor
-#define ARMOR_BOOTS_PLATED list("blunt" = 10, "slash" = 100, "stab" = 80, "piercing" = 75, "fire" = 0, "acid" = 0)
-#define ARMOR_BOOTS_PLATED_IRON list("blunt" = 10, "slash" = 100, "stab" = 70, "piercing" = 50, "fire" = 0, "acid" = 0)
-#define ARMOR_BOOTS_BAD list("blunt" = 30, "slash" = 10, "stab" = 20, "piercing" = 0, "fire" = 0, "acid" = 0)
-#define ARMOR_BOOTS list("blunt" = 30, "slash" = 40, "stab" = 60, "piercing" = 20, "fire" = 0, "acid" = 0)
+#define ARMOR_BOOTS_PLATED list("blunt" = DR_LIGHT, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_BOOTS_PLATED_IRON list("blunt" = DR_LIGHT, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_BOOTS_BAD list("blunt" = DR_MEDIUM, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_NONE, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_BOOTS list("blunt" = DR_MEDIUM, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 
 // Glove Armor
-#define ARMOR_GLOVES_LEATHER list("blunt" = 60, "slash" = 10, "stab" = 20, "piercing" = 0, "fire" = 0, "acid" = 0)
-#define ARMOR_GLOVES_LEATHER_GOOD list("blunt" = 60, "slash" = 25, "stab" = 40, "piercing" = 20, "fire" = 0, "acid" = 0)
-#define ARMOR_GLOVES_CHAIN list("blunt" = 20, "slash" = 100, "stab" = 60, "piercing" = 50, "fire" = 0, "acid" = 0)
-#define ARMOR_GLOVES_PLATE list("blunt" = 5, "slash" = 100, "stab" = 80, "piercing" = 75, "fire" = 0, "acid" = 0)
-#define ARMOR_GLOVES_PLATE_GOOD list("blunt" = 20, "slash" = 100, "stab" = 80, "piercing" = 85, "fire" = 0, "acid" = 0)
+#define ARMOR_GLOVES_LEATHER list("blunt" = DR_HEAVY, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_NONE, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_GLOVES_LEATHER_GOOD list("blunt" = DR_HEAVY, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_GLOVES_CHAIN list("blunt" = DR_LIGHT, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_GLOVES_PLATE list("blunt" = DR_LIGHT, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_GLOVES_PLATE_GOOD list("blunt" = DR_LIGHT, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_LIGHT, "acid" = DR_NONE)
 
 //  Head Armor
-#define ARMOR_HEAD_CLOTHING list("blunt" = 0, "slash" = 20, "stab" = 20, "piercing" = 0, "fire" = 0, "acid" = 0)
-#define ARMOR_HEAD_BAD list("blunt" = 50, "slash" = 20, "stab" = 30, "piercing" = 10, "fire" = 0, "acid" = 0)
-#define ARMOR_HEAD_HELMET_BAD list("blunt" = 50, "slash" = 50, "stab" = 50, "piercing" = 20, "fire" = 0, "acid" = 0)
-#define ARMOR_HEAD_HELMET list("blunt" = 50, "slash" = 100, "stab" = 80, "piercing" = 60, "fire" = 0, "acid" = 0)
-#define ARMOR_HEAD_HELMET_VISOR list("blunt" = 40, "slash" = 100, "stab" = 80, "piercing" = 65, "fire" = 0, "acid" = 0)
-#define ARMOR_HEAD_PSYDON list("blunt" = 70, "slash" = 70, "stab" = 50, "piercing" = 30, "fire" = 0, "acid" = 0)	//Yeah they just have their own thing going on.
-#define ARMOR_HEAD_LEATHER list("blunt" = 90, "slash" = 60, "stab" = 30, "piercing" = 20, "fire" = 0, "acid" = 0)
+#define ARMOR_HEAD_CLOTHING list("blunt" = DR_NONE, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_NONE, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_HEAD_BAD list("blunt" = DR_HEAVY, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_HEAD_HELMET_BAD list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_HEAD_HELMET list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_HEAD_HELMET_VISOR list("blunt" = DR_MEDIUM, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_HEAD_PSYDON list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_LIGHT, "acid" = DR_NONE)	//Yeah they just have their own thing going on.
+#define ARMOR_HEAD_LEATHER list("blunt" = DR_ULTRA, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 
 // Mask Armor
-#define ARMOR_MASK_EYEPATCH list("blunt" = 5, "slash" = 10, "stab" = 5, "piercing" = 2, "fire" = 0, "acid" = 0)
-#define ARMOR_MASK_METAL_BAD list("blunt" = 50, "slash" = 50, "stab" = 50, "piercing" = 50, "fire" = 0, "acid" = 0)
-#define ARMOR_MASK_METAL list("blunt" = 50, "slash" = 100, "stab" = 80, "piercing" = 50, "fire" = 0, "acid" = 0)
+#define ARMOR_MASK_EYEPATCH list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_MASK_METAL_BAD list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_MASK_METAL list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
 
 // Neck Armor
-#define ARMOR_BEVOR list("blunt" = 20, "slash" = 100, "stab" = 80, "piercing" = 70, "fire" = 0, "acid" = 0)
-#define ARMOR_GORGET list("blunt" = 40, "slash" = 100, "stab" = 80, "piercing" = 50, "fire" = 0, "acid" = 0)
-#define ARMOR_NECK_BAD list("blunt" = 50, "slash" = 50, "stab" = 40, "piercing" = 20, "fire" = 0, "acid" = 0)
+#define ARMOR_BEVOR list("blunt" = DR_LIGHT, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_GORGET list("blunt" = DR_MEDIUM, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_NECK_BAD list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 
 //Pants Armor
-#define ARMOR_PANTS_LEATHER list("blunt" = 80, "slash" = 50, "stab" = 40, "piercing" = 10, "fire" = 0, "acid" = 0)
-#define ARMOR_PANTS_CHAIN list("blunt" = 40, "slash" = 100, "stab" = 80, "piercing" = 50, "fire" = 0, "acid" = 0)
-#define ARMOR_PANTS_BRIGANDINE list("blunt" = 40, "slash" = 70, "stab" = 70, "piercing" = 50, "fire" = 0, "acid" = 0)
+#define ARMOR_PANTS_LEATHER list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_PANTS_CHAIN list("blunt" = DR_MEDIUM, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE)
+#define ARMOR_PANTS_BRIGANDINE list("blunt" = DR_MEDIUM, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 
 //Antag / Special / Unique armor defines
-#define ARMOR_REGENERATING_BROKEN list("blunt" = 10, "slash" = 10, "stab" = 10, "piercing" = 10, "fire" = 0, "acid" = 0)
-#define ARMOR_VAMP list("blunt" = 100, "slash" = 100, "stab" = 90, "piercing" = 80, "fire" = 0, "acid" = 0)
-#define ARMOR_WWOLF list("blunt" = 100, "slash" = 90, "stab" = 80, "piercing" = 70, "fire" = 40, "acid" = 0)
-// Gnoll hide tiers scale monotonically: STRONG > STANDARD > WEAK for every damage type (+20/tier).
+#define ARMOR_REGENERATING_BROKEN list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_VAMP list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_WWOLF list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+// Gnoll hide tiers scale monotonically: STRONG > STANDARD > WEAK for every damage type.
 // Hide keeps its character (slightly tougher vs slash/stab than blunt) but the tank hide is no longer
 // blunt-weakest. piercing is largely moot — gnolls are TRAIT_PIERCEIMMUNE.
-#define ARMOR_GNOLL_WEAK list("blunt" = 60, "slash" = 70, "stab" = 65, "piercing" = 60, "fire" = 40, "acid" = 0)
-#define ARMOR_GNOLL_STANDARD list("blunt" = 80, "slash" = 90, "stab" = 85, "piercing" = 80, "fire" = 40, "acid" = 0)
-#define ARMOR_GNOLL_STRONG list("blunt" = 100, "slash" = 110, "stab" = 105, "piercing" = 100, "fire" = 40, "acid" = 0)
-#define ARMOR_DRAGONSCALE list("blunt" = 100, "slash" = 100, "stab" = 100, "fire" = 50, "acid" = 0)
-#define ARMOR_ASCENDANT list("blunt" = 50, "slash" = 100, "stab" = 80, "piercing" = 80, "fire" = 0, "acid" = 0)
-#define ARMOR_SPELLSINGER list("blunt" = 70, "slash" = 70, "stab" = 50, "piercing" = 30, "fire" = 0, "acid" = 0)
-#define ARMOR_GRUDGEBEARER list("blunt" = 40, "slash" = 200, "stab" = 200, "piercing" = 100, "fire" = 0, "acid" = 0)
-#define ARMOR_ZIZOCONCSTRUCT list("blunt" = 60, "slash" = 70, "stab" = 70, "piercing" = 60, "fire" = 40, "acid" = 10)
+#define ARMOR_GNOLL_WEAK list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_GNOLL_STANDARD list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_GNOLL_STRONG list("blunt" = DR_ULTRA, "slash" = DBLOCK_BSTEEL, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_HEAVY, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_DRAGONSCALE list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "fire" = DR_HEAVY, "acid" = DR_NONE)
+#define ARMOR_ASCENDANT list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_SPELLSINGER list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_GRUDGEBEARER list("blunt" = DR_MEDIUM, "slash" = DBLOCK_BSTEEL, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_HEAVY, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_ZIZOCONCSTRUCT list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM, "acid" = DR_LIGHT)
 // Blocks every hit, at least once
-#define ARMOR_GRONN_LIGHT list("blunt" = 80, "slash" = 80, "stab" = 30, "piercing" = 30, "fire" = 0, "acid" = 0)
+#define ARMOR_GRONN_LIGHT list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)

--- a/code/__DEFINES/roguetown/armor_defines.dm
+++ b/code/__DEFINES/roguetown/armor_defines.dm
@@ -178,7 +178,7 @@
 
 //Antag / Special / Unique armor defines
 #define ARMOR_REGENERATING_BROKEN list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
-#define ARMOR_VAMP list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_VAMP list("blunt" = DR_ULTRA, "slash" = DBLOCK_BSTEEL, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_BSTEEL, "fire" = DR_NONE, "acid" = DR_NONE) // Blacksteel antag plate — top of the DBLOCK scale.
 #define ARMOR_WWOLF list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 // Gnoll hide tiers scale monotonically: STRONG > STANDARD > WEAK for every damage type.
 // Hide keeps its character (slightly tougher vs slash/stab than blunt) but the tank hide is no longer

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -70,3 +70,44 @@
 	tag = ARMORID // update tag in case armor values were edited
 
 #undef ARMORID
+
+/*------------------------\
+|     TIER READOUTS       |
+\------------------------*/
+// The two armor families use different scales, so a bare number can't be named without
+// knowing its damage type. slash/stab/piercing are DBLOCK (0-4); blunt/fire/acid are DR (0-5).
+
+/proc/armor_tier_name(tier, d_type)
+	if(isnull(tier))
+		tier = 0
+	if(d_type in ARMOR_DBLOCK_TYPES)
+		switch(tier)
+			if(-INFINITY to DBLOCK_NONE)
+				return "None"
+			if(DBLOCK_LIGHT)
+				return "Light"
+			if(DBLOCK_MEDIUM)
+				return "Medium"
+			if(DBLOCK_HEAVY)
+				return "Heavy"
+			if(DBLOCK_BSTEEL to INFINITY)
+				return "Bsteel"
+	switch(tier)
+		if(-INFINITY to DR_NONE)
+			return "None"
+		if(DR_LIGHT)
+			return "Light"
+		if(DR_MEDIUM)
+			return "Medium"
+		if(DR_HEAVY)
+			return "Heavy"
+		if(DR_SUPER)
+			return "Super"
+		if(DR_ULTRA to INFINITY)
+			return "Ultra"
+
+// Weapon penetration shares the DBLOCK scale (0-4) so the two can be compared directly.
+// Clamps rather than erroring: BLUNT_DEFAULT_PENFACTOR is -100, which reads as None (correctly -
+// it can never meet any tier).
+/proc/pen_tier_name(tier)
+	return armor_tier_name(tier, "stab")

--- a/code/datums/components/layer_armor.dm
+++ b/code/datums/components/layer_armor.dm
@@ -27,27 +27,22 @@
 		"piercing" = 0,
 	)
 
-	/// Armor rating a given damage type can be repaired up to.
+	/// Armor tier a given damage type can be repaired up to. blunt uses the DR scale, the rest DBLOCK.
 	var/list/layer_max = list(
-		"blunt" = 100,
-		"slash" = 100,
-		"stab" = 100,
-		"piercing" = 100,
+		"blunt" = DR_ULTRA,
+		"slash" = DBLOCK_BSTEEL,
+		"stab" = DBLOCK_BSTEEL,
+		"piercing" = DBLOCK_BSTEEL,
 	)
 
-	/// New hit count requirements per shredded layer. ex. going from 100 to 90 will require 5 hits, 90 to 80 will require 10, etc.
+	/// New hit count requirements per armor tier, keyed by the tier the armor is AT after a shred.
 	/// MAKE SURE THE VALUES CORRELATE WITH YOUR SHRED_AMT AND STARTING ARMOR VALUES IF YOU WISH TO USE THIS
 	var/list/hits_per_layer = list(
-		"100" 	= 10,
-		"90" 	= 10,
-		"80" 	= 20,
-		"70" 	= 25,
-		"60" 	= 30,
-		"50"	= 30,
-		"40"	= 30,
-		"30"	= 30,
-		"20"	= 50,
-		"10"	= 100,
+		"5" 	= 10,
+		"4" 	= 10,
+		"3" 	= 10,
+		"2"		= 20,
+		"1"		= 30,
 	)
 
 	/// A multiplier to a damage type. One hit from that type will equal this number if it's bigger than 1. ONLY USE WHOLE NUMBERS.
@@ -61,8 +56,8 @@
 	/// Populated during repair_check(), leave empty.
 	var/list/repairable_damtypes = list()
 
-	/// How much armor is lost when a layer is shredded. Increments of 10 are recommended, as they correspond to letter tiers on examine (S -> A+ -> A -> B+ etc)
-	var/shred_amt = 10
+	/// How many armor tiers are lost when a layer is shredded.
+	var/shred_amt = 1
 
 	/// What the next layer's hit threshold will increase by if the hits_per_layer list is empty. Doubles at 50 integrity and below by default.
 	var/hits_default = 10
@@ -115,7 +110,7 @@
 					shred_layer(damage_flag)
 	else if(damage_flag in damtypes)
 		var/obj/item/I = parent
-		if(I.armor.vars[damage_flag] > 100)	//S+ layer, it can't take direct damage, so there's an exception.
+		if(I.armor.vars[damage_flag] >= DBLOCK_BSTEEL)	//Top-tier layer, it can't take direct damage, so there's an exception.
 			add_hit(damage_flag)
 			if(check_hit(damage_flag))
 				shred_layer(damage_flag)
@@ -235,10 +230,8 @@
 /datum/component/layeredarmor/proc/shred_layer(damtype)
 	var/obj/item/I = parent
 	if(I.armor)
-		if(I.armor.vars[damtype] > 100)
-			I.armor.vars[damtype] = 100
-		else if(I.armor.vars[damtype] > 0)
-			I.armor.vars[damtype] -= shred_amt
+		if(I.armor.vars[damtype] > 0)
+			I.armor.vars[damtype] = max(I.armor.vars[damtype] - shred_amt, 0)
 		playsound(I, shred_sound, 100)
 		I.visible_message(span_warning("A <b>[damtype]</b> layer is shredded from [I]!"))
 		adjusthits(damtype, I.armor.vars[damtype])
@@ -253,9 +246,9 @@
 					new_threshold = hits_per_layer[num2text(check)]
 			if(!new_threshold)	//We have a mismatch in hits_per_layer with our armor value (very bad) or its empty. Either way, we fall back to hits_default.
 				switch(check)
-					if(60 to 100)
+					if(3 to INFINITY)
 						new_threshold = hits_default
-					if(0 to 59)
+					if(0 to 2)
 						new_threshold = hits_default * 2
 			hits_to_shred[damtype] = new_threshold
 			hit_count[damtype] = 0
@@ -263,11 +256,7 @@
 /datum/component/layeredarmor/proc/add_layer(damtype)
 	var/obj/item/I = parent
 	if(I.armor)
-		I.armor.vars[damtype] += shred_amt * layer_repair
-		if(layer_max[damtype] > 100 && I.armor.vars[damtype] > 100)	//We have a layer that has a max of above 100, and our repair just made us go over 100.
-			I.armor.vars[damtype] = layer_max[damtype]
-		else
-			I.armor.vars[damtype] = min(I.armor.vars[damtype], 100, layer_max[damtype])	//Make sure it's never above 100, or the layer_max of that type.
+		I.armor.vars[damtype] = min(I.armor.vars[damtype] + shred_amt * layer_repair, layer_max[damtype])	//Make sure it's never above the layer_max of that type.
 		adjusthits(damtype, I.armor.vars[damtype])
 
 /datum/component/layeredarmor/proc/repair_check()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1428,10 +1428,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(C.armor)
 			var/defense = "<u><b>ABSORPTION: </b></u><br>"
 			var/datum/armor/def_armor = C.armor
+			// No tier name on blunt: it never resolves against weapon PEN (absorb path), so naming
+			// its tier in the PEN vocabulary would imply a comparison that never happens.
 			defense += "[colorgrade_rating("BLUNT", def_armor.blunt, elaborate = TRUE)] | "
-			defense += "[colorgrade_rating("SLASH", def_armor.slash, elaborate = TRUE)] | "
-			defense += "[colorgrade_rating("STAB", def_armor.stab, elaborate = TRUE)] | "
-			defense += "[colorgrade_rating("PIERCING", def_armor.piercing, elaborate = TRUE)] "
+			defense += "[colorgrade_rating("SLASH", def_armor.slash, elaborate = TRUE, d_type = "slash")] | "
+			defense += "[colorgrade_rating("STAB", def_armor.stab, elaborate = TRUE, d_type = "stab")] | "
+			defense += "[colorgrade_rating("PIERCING", def_armor.piercing, elaborate = TRUE, d_type = "piercing")] "
 			str += "[defense]<br>"
 		else
 			str += "NO DEFENSE"

--- a/code/game/objects/items/rogueitems/ropechainbola.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola.dm
@@ -184,7 +184,7 @@
 	name = "strike"
 	blade_class = BCLASS_BLUNT
 	attack_verb = list("whips", "strikes", "smacks")
-	penfactor = 0 //40
+	penfactor = PEN_NONE //40
 	chargetime = 5
 	item_d_type = "slash"
 

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -38,7 +38,7 @@
 	var/datum/looping_sound/chargedloop = null
 	var/keep_looping = TRUE
 	var/damfactor = 1 //multiplied by weapon's force for damage
-	var/penfactor = 0 //see armor_penetration
+	var/penfactor = PEN_NONE //see armor_penetration
 	var/intent_intdamage_factor = 1 // Whether the intent itself has integrity damage modifier. Used for rend.
 	var/item_d_type = "blunt" // changes the item's attack type ("blunt" - area-pressure attack, "slash" - line-pressure attack, "stab" - point-pressure attack)
 	var/charging_slowdown = 0
@@ -56,8 +56,6 @@
 	var/obj/effect/mob_charge_effect = null // The effect to be added (on top) of the mob while it is charging
 	var/custom_swingdelay = null	//Custom icon for its swingdelay.
 	//The below is for chipping on intents. Damage applied through armour, as a mechanic.
-	var/blunt_chipping = FALSE//Is this even capable of it?
-	var/blunt_chip_strength = null//How strong?
 	/// Effective range for penfactor to apply fully.
 	var/effective_range = null
 	///	Effective range type. Can be Exact, Below or Above. Be sure to set this if you use effective_range!
@@ -155,18 +153,6 @@
 		inspec += "\nThis intent will cost some sharpness for every attack made."
 	if(unarmed)
 		inspec += "\n<b>Swift:</b> Harder to parry or dodge when faster than your opponent."
-	if(blunt_chipping)
-		var/chip_strength
-		switch(blunt_chip_strength)
-			if(BLUNT_CHIP_MINUSCULE)
-				chip_strength = "minuscule"
-			if(BLUNT_CHIP_WEAK)
-				chip_strength = "middling"
-			if(BLUNT_CHIP_STRONG)
-				chip_strength = "considerable"
-			if(BLUNT_CHIP_ABSURD)
-				chip_strength = "significant"
-		inspec += "\nA [chip_strength] sum of damage will bypass armour, if the target has no padded protection."
 	inspec += "<br>----------------------"
 
 	to_chat(user, "[inspec.Join()]")
@@ -356,14 +342,14 @@
 /datum/intent/stab/militia
 	name = "militia stab"
 	damfactor = 1.1
-	penfactor = 50
+	penfactor = PEN_HEAVY
 
 /datum/intent/pick //now like icepick intent, we really went in a circle huh
 	name = "pick"
 	icon_state = "inpick"
 	attack_verb = list("picks","impales")
 	hitsound = list('sound/combat/hits/pick/genpick (1).ogg', 'sound/combat/hits/pick/genpick (2).ogg')
-	penfactor = 80
+	penfactor = PEN_BSTEEL
 	animname = "strike"
 	item_d_type = "stab"
 	blade_class = BCLASS_PICK
@@ -375,7 +361,7 @@
 	icon_state = "inpick"
 	attack_verb = list("drills","augers")
 	hitsound = list('sound/combat/hits/pick/genpick (1).ogg', 'sound/combat/hits/pick/genpick (2).ogg')
-	penfactor = 80
+	penfactor = PEN_BSTEEL
 	animname = "strike"
 	item_d_type = "stab"
 	blade_class = BCLASS_DRILL
@@ -389,7 +375,7 @@
 	icon_state = "inpick"
 	attack_verb = list("stabs", "impales")
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 60
+	penfactor = PEN_BSTEEL
 	damfactor = 1.1
 	clickcd = CLICK_CD_CHARGED
 	releasedrain = 4
@@ -402,7 +388,7 @@
 	icon_state = "inpick"
 	attack_verb = list("picks","impales")
 	hitsound = list('sound/combat/hits/pick/genpick (1).ogg', 'sound/combat/hits/pick/genpick (2).ogg')
-	penfactor = 80
+	penfactor = PEN_BSTEEL
 	animname = "strike"
 	item_d_type = "stab"
 	blade_class = BCLASS_PICK
@@ -514,7 +500,7 @@
 	misscost = 1
 	releasedrain = 1	//More than punch cus pen factor.
 	swingdelay = 0
-	penfactor = 10
+	penfactor = PEN_NONE
 	candodge = TRUE
 	canparry = TRUE
 	blade_class = BCLASS_CUT
@@ -604,7 +590,7 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = "punch_hard"
 	chargetime = 0
-	penfactor = 10
+	penfactor = PEN_NONE
 	swingdelay = 0
 	candodge = TRUE
 	canparry = TRUE
@@ -618,7 +604,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = "smallslash"
 	chargetime = 0
-	penfactor = 0
+	penfactor = PEN_NONE
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE
@@ -633,7 +619,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = "smallslash"
 	chargetime = 0
-	penfactor = 0
+	penfactor = PEN_NONE
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE
@@ -648,7 +634,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = list("genchop", "genslash")
 	chargetime = 0
-	penfactor = 0
+	penfactor = PEN_NONE
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE
@@ -662,7 +648,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = list("genthrust", "genstab")
 	chargetime = 0
-	penfactor = 0
+	penfactor = PEN_NONE
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE
@@ -694,7 +680,7 @@
 	animname = "strike"
 	hitsound = list('sound/combat/hits/blunt/daze_hit.ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	swingdelay = 6
 	damfactor = 1
 	item_d_type = "blunt"

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -113,8 +113,13 @@
 		inspec += "\n<b>Effective Range:</b> [suffix] [effective_range] paces"
 	if(damfactor != 1)
 		inspec += "\n<b>Damage:</b> [damfactor]"
-	if(penfactor)
-		inspec += "\n<b>Armor Penetration:</b> [penfactor < 0 ? "NONE" : penfactor]"
+	// Named tier rather than the raw number - it's compared directly against the armor's DBLOCK
+	// tier, so both readouts should speak the same language. State it outright for anything that
+	// resolves against armor tiers, so "None" reads as a real answer instead of a blank. Blunt
+	// intents are absorbed and never check PEN, so they stay silent unless they carry a value.
+	// Negative penfactors (BLUNT_DEFAULT_PENFACTOR) name themselves None.
+	if((item_d_type in ARMOR_DBLOCK_TYPES) || penfactor)
+		inspec += "\n<b>Armor Penetration:</b> [pen_tier_name(penfactor)]"
 	if(get_chargetime())
 		inspec += "\n<b>Charge Time</b>"
 	if(movement_interrupt)

--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -7,7 +7,7 @@
 	attack_verb = list("cuts", "slashes")
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	animname = "cut"
-	penfactor = 20
+	penfactor = PEN_LIGHT
 	chargetime = 0
 	item_d_type = "slash"
 
@@ -18,7 +18,7 @@
 	attack_verb = list("chops", "hacks")
 	animname = "chop"
 	hitsound = list('sound/combat/hits/bladed/wpn_impact_blunt2hand_flesh_01.ogg', 'sound/combat/hits/bladed/wpn_impact_blunt2hand_flesh_02.ogg', 'sound/combat/hits/bladed/wpn_impact_blunt2hand_flesh_03.ogg')
-	penfactor = 35
+	penfactor = PEN_MEDIUM
 	swingdelay = 10
 	clickcd = 14
 	item_d_type = "slash"
@@ -27,19 +27,19 @@
 	reach = 2
 
 /datum/intent/axe/chop/stone
-	penfactor = 5
+	penfactor = PEN_NONE
 
 /datum/intent/axe/chop/battle
 	damfactor = 1.2 //36 on battleaxe
-	penfactor = 40
+	penfactor = PEN_MEDIUM
 
 /datum/intent/axe/chop/battle/halberd
 	damfactor = 1.3
 	swingdelay = 12
-	penfactor = 20
+	penfactor = PEN_LIGHT
 
 /datum/intent/axe/cut/battle
-	penfactor = 25
+	penfactor = PEN_LIGHT
 
 /datum/intent/axe/bash
 	name = "bash"
@@ -49,7 +49,7 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	swingdelay = 5
 	damfactor = 1.1
 	item_d_type = "blunt"
@@ -470,7 +470,7 @@
 	animname = "strike"
 	blade_class = null	//We don't use a blade class because it has on damage.
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	swingdelay = 2	//Small delay to hook
 	damfactor = 0.1	//No real damage
 	clickcd = 22	//Can't spam this; long delay.
@@ -538,7 +538,7 @@
 	name = "ćiupaga lunge"
 	desc = "Grip your ćiupaga by the tail-end of the handle and swing in a circular motion to reach further ahead. It will deal extra damage if perfectly positioned, otherwise you'll just hit them with the handle."
 	damfactor = 1.75
-	penfactor = 42
+	penfactor = PEN_MEDIUM
 	blade_class = BCLASS_CHOP
 	reach = 2
 	swingdelay = 2

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -6,40 +6,26 @@
 	attack_verb = list("strikes", "hits")
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	damfactor = 1.1
 	swingdelay = 0
 	icon_state = "instrike"
 	item_d_type = "blunt"
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_WEAK
 
 /datum/intent/mace/strike/reach
 	reach = 2
-
-// Dedicated maul intents: inherit all ES mace strike/smash behaviour (damage,
-// knockback, sounds) and only raise the chip tier to match RW PR #607.
-/datum/intent/mace/strike/maul
-	blunt_chip_strength = BLUNT_CHIP_STRONG
 
 /datum/intent/mace/smash
 	name = "smash"
 	blade_class = BCLASS_SMASH
 	attack_verb = list("smashes")
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	damfactor = 1.5
 	swingdelay = 10
 	clickcd = 14
 	icon_state = "insmash"
 	item_d_type = "blunt"
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_STRONG
-
-/datum/intent/mace/smash/maul
-	blunt_chip_strength = BLUNT_CHIP_ABSURD
 
 /datum/intent/mace/smash/reach
 	reach = 2
@@ -59,7 +45,7 @@
 	recovery = 10
 	warnie = "mobwarning"
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 40 //Same as a dagger.
+	penfactor = PEN_MEDIUM //Same as a dagger.
 	item_d_type = "stab"
 
 //blunt objs ฅ^•ﻌ•^ฅ
@@ -209,11 +195,11 @@
 
 /datum/intent/mace/strike/wood
 	hitsound = list('sound/combat/hits/blunt/woodblunt (1).ogg', 'sound/combat/hits/blunt/woodblunt (2).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 
 /datum/intent/mace/smash/wood
 	hitsound = list('sound/combat/hits/blunt/woodblunt (1).ogg', 'sound/combat/hits/blunt/woodblunt (2).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 
 /datum/intent/mace/smash/wood/ranged
 	reach = 2
@@ -586,7 +572,7 @@
 	animname = "stab"
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	no_early_release = TRUE
-	penfactor = 20
+	penfactor = PEN_LIGHT
 	damfactor = 0.8
 	item_d_type = "stab"
 
@@ -600,7 +586,7 @@
 	misscost = 1
 	swingdelay = 15
 	clickcd = 15
-	penfactor = 80
+	penfactor = PEN_BSTEEL
 	damfactor = 0.9
 	item_d_type = "stab"
 
@@ -621,8 +607,8 @@
 /obj/item/rogueweapon/mace/maul
 	force = 12 //Don't one-hand this.
 	force_wielded = 32 //-3 compared to grand mace(steel goden). Better intents.
-	possible_item_intents = list(/datum/intent/mace/strike/maul)
-	gripped_intents = list(/datum/intent/mace/strike/maul, /datum/intent/mace/smash/maul, /datum/intent/effect/daze, /datum/intent/effect/hobble)
+	possible_item_intents = list(/datum/intent/mace/strike)
+	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/effect/daze, /datum/intent/effect/hobble)
 	name = "maul"
 	desc = "Who would need something this large? It looks like it was made for tearing down walls, rather than men."
 	icon_state = "sledge"
@@ -673,7 +659,7 @@
 	hitsound = list('sound/combat/hits/blunt/shovel_hit3.ogg')
 	swingdelay = 6
 	damfactor = 0.8
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	clickcd = CLICK_CD_HEAVY
 	item_d_type = "blunt"
 	intent_effect = /datum/status_effect/debuff/hobbled

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -31,12 +31,9 @@
 	attack_verb = list("strikes", "hits")
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	icon_state = "instrike"
 	item_d_type = "blunt"
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_WEAK
 
 /datum/intent/flail/strike/matthiosflail
 	reach = 2
@@ -48,22 +45,17 @@
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
 	recovery = 15
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	reach = 2
 	icon_state = "instrike"
 	item_d_type = "blunt"
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_WEAK
 
 /datum/intent/flail/strike/smash
 	name = "smash"
-	//Flail smash mirrors RW's mace-inheriting smash: stronger chip than the strike.
-	blunt_chip_strength = BLUNT_CHIP_STRONG
 	chargetime = 5
 	chargedrain = 2
 	no_early_release = TRUE
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	recovery = 10
 	damfactor = 1.6
 	chargedloop = /datum/looping_sound/flailswing
@@ -90,7 +82,7 @@
 	no_early_release = TRUE
 	recovery = 30
 	damfactor = 1.5
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	reach = 2
 	chargedloop = /datum/looping_sound/flailswing
 	keep_looping = TRUE

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -10,7 +10,7 @@
 	animname = "cut"
 	blade_class = BCLASS_CUT
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
-	penfactor = 0
+	penfactor = PEN_NONE
 	chargetime = 0
 	swingdelay = 0
 	clickcd = 10
@@ -23,7 +23,7 @@
 	animname = "stab"
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 40
+	penfactor = PEN_MEDIUM
 	chargetime = 0
 	clickcd = 8
 	item_d_type = "stab"
@@ -33,7 +33,7 @@
 	icon_state = "inpick"
 	attack_verb = list("stabs", "impales")
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 75
+	penfactor = PEN_BSTEEL
 	clickcd = 14
 	swingdelay = 12
 	damfactor = 1.1
@@ -47,7 +47,7 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/bluntsmall (1).ogg', 'sound/combat/hits/blunt/bluntsmall (2).ogg', 'sound/combat/hits/kick/kick.ogg')
 	damfactor = 1
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	clickcd = 14
 	recovery = 10
 	item_d_type = "blunt"
@@ -61,7 +61,7 @@
 	animname = "chop"
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
-	penfactor = 10
+	penfactor = PEN_NONE
 	damfactor = 1.5
 	swingdelay = 5
 	clickcd = 10
@@ -69,7 +69,7 @@
 
 /datum/intent/dagger/chop/cleaver
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
-	penfactor = 30
+	penfactor = PEN_MEDIUM
 
 //knife and dagger objs ฅ^•ﻌ•^ฅ
 
@@ -550,8 +550,8 @@
 	max_integrity = 50
 	// Tossblades only get armor-pierce on the thrown path; melee stabs go
 	// through the normal armor check so they can't double-dip with poisons.
-	armor_penetration = 0
-	thrown_armor_penetration = 30
+	armor_penetration = PEN_NONE
+	thrown_armor_penetration = PEN_MEDIUM
 	wdefense = 1
 	icon_state = "throw_knifei"
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 25, "embedded_fall_chance" = 10)
@@ -578,7 +578,7 @@
 	icon_state = "easttossblade"
 	throwforce = 30
 	max_integrity = 100
-	thrown_armor_penetration = 40
+	thrown_armor_penetration = PEN_MEDIUM
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 60, "embedded_fall_chance" = 5)
 
 /obj/item/rogueweapon/huntingknife/throwingknife/aalloy
@@ -595,7 +595,7 @@
 	item_state = "bone_dagger"
 	throwforce = 28
 	max_integrity = 100
-	thrown_armor_penetration = 40
+	thrown_armor_penetration = PEN_MEDIUM
 	icon_state = "throw_knifes"
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 30, "embedded_fall_chance" = 5)
 	sellprice = 2
@@ -611,7 +611,7 @@
 	item_state = "bone_dagger"
 	force = 10
 	throwforce = 20
-	thrown_armor_penetration = 50
+	thrown_armor_penetration = PEN_HEAVY
 	max_integrity = 150
 	wdefense = 3
 	icon_state = "throw_knifep"

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -10,7 +10,7 @@
 	clickcd = CLICK_CD_CHARGED
 	warnie = "mobwarning"
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 50
+	penfactor = PEN_HEAVY
 	item_d_type = "stab"
 	effective_range = 2
 	effective_range_type = EFF_RANGE_EXACT
@@ -31,7 +31,7 @@
 	clickcd = CLICK_CD_HEAVY + 3
 	swingdelay = 5
 	damfactor = 1.5
-	penfactor = 35
+	penfactor = PEN_MEDIUM
 	reach = 2
 	icon_state = "inlance"
 	attack_verb = list("lances", "runs through", "skewers")
@@ -42,27 +42,24 @@
 	reach = 1
 	swingdelay = 14
 	damfactor = 1.6
-	penfactor = 50
+	penfactor = PEN_HEAVY
 	clickcd = CLICK_CD_RESIST
 	effective_range = null
 	effective_range_type = EFF_RANGE_NONE
 	sharpness_penalty = 3
 
 /datum/intent/spear/thrust/militia
-	penfactor = 30
+	penfactor = PEN_MEDIUM
 
 /datum/intent/spear/bash
 	name = "bash"
 	blade_class = BCLASS_BLUNT
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	icon_state = "inbash"
 	attack_verb = list("bashes", "strikes")
-	penfactor = 10
+	penfactor = PEN_NONE
 	damfactor = 0.8
 	item_d_type = "blunt"
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_STRONG
 
 /datum/intent/spear/bash/ranged
 	reach = 2
@@ -113,7 +110,7 @@
 /datum/intent/sword/cut/miaodao
 	reach = 2
 	swingdelay = 2
-	penfactor = 20
+	penfactor = PEN_LIGHT
 
 /datum/intent/sword/cut/miaodao/fast
 	clickcd = 10
@@ -128,7 +125,7 @@
 
 /datum/intent/sword/thrust/estoc
 	name = "thrust"
-	penfactor = 57	//At 57 pen + 25 base (82 total), you will always pen 80 stab armor, but you can't do it at range unlike a spear.
+	penfactor = PEN_HEAVY	//Estoc: dedicated point-blank plate-piercing thrust (was 57 pen).
 	swingdelay = 8
 
 /datum/intent/sword/lunge
@@ -139,7 +136,7 @@
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	reach = 2
-	penfactor = 20
+	penfactor = PEN_NONE
 	damfactor = 1.3	//Zwei will still deal ~7-10 more damage at the same range, depending on user's STR.
 	swingdelay = 10
 
@@ -148,7 +145,7 @@
 	blade_class = BCLASS_BLUNT
 	icon_state = "inbash"
 	attack_verb = list("bashes", "strikes")
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	damfactor = 1.3
 	item_d_type = "blunt"
 
@@ -161,7 +158,7 @@
 	blade_class = BCLASS_CHOP
 	reach = 1
 	swingdelay = 15
-	penfactor = -100 // hard set to not penetrate armor as its original design intended
+	penfactor = PEN_NONE // hard set to not penetrate armor as its original design intended
 	damfactor = 2.5
 	clickcd = CLICK_CD_CHARGED
 	no_early_release = TRUE
@@ -172,7 +169,7 @@
 
 /datum/intent/rend/reach
 	name = "long rend"
-	penfactor = -100
+	penfactor = PEN_NONE
 	misscost = 5
 	swingdelay = 15
 	clickcd = CLICK_CD_HEAVY
@@ -199,7 +196,7 @@
 	blade_class = BCLASS_PEEL
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	clickcd = CLICK_CD_CHARGED
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	swingdelay = 5
 	damfactor = 0.05
 	item_d_type = "slash"
@@ -210,19 +207,13 @@
 
 /datum/intent/spear/bash/ranged/quarterstaff
 	damfactor = 1
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_WEAK//Use this instead of thrust for chip damage.
 
 /datum/intent/spear/thrust/quarterstaff
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/bluntsmall (1).ogg', 'sound/combat/hits/blunt/bluntsmall (2).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	damfactor = 1.3 // Adds up to be slightly stronger than an unenhanced ebeak strike.
 	chargetime = 6 // Meant to be stronger than a bash, but with a delay.
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_MINUSCULE//See above.
 
 /datum/intent/spear/thrust/lance
 	damfactor = 1.5 // Turns its base damage into 30 on the 2hand thrust. It keeps the spear thrust one handed.
@@ -233,7 +224,7 @@
 	attack_verb = list("lances", "runs through", "skewers")
 	animname = "stab"
 	item_d_type = "stab"
-	penfactor = BLUNT_DEFAULT_PENFACTOR // Not a mistake, to prevent it from nuking through armor.
+	penfactor = PEN_NONE // Not a mistake, to prevent it from nuking through armor.
 	chargetime = 4 SECONDS
 	damfactor = 4 // 80 damage on hit. It is gonna hurt.
 	reach = 3 // Yep! 3 tiles
@@ -955,11 +946,11 @@
 	sellprice = 40
 
 /datum/intent/spear/thrust/eaglebeak
-	penfactor = 50
+	penfactor = PEN_HEAVY
 	damfactor = 1
 
 /datum/intent/spear/thrust/glaive
-	penfactor = 50
+	penfactor = PEN_HEAVY
 	damfactor = 1.1
 	chargetime = 0
 
@@ -968,7 +959,6 @@
 	swingdelay = 12
 	clickcd = 14
 	damfactor = 1.3
-	blunt_chip_strength = BLUNT_CHIP_ABSURD
 
 /obj/item/rogueweapon/spear/bronze
 	name = "Bronze Spear"

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -6,7 +6,7 @@
 	animname = "cut"
 	blade_class = BCLASS_CUT
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
-	penfactor = 0
+	penfactor = PEN_LIGHT
 	chargetime = 0
 	swingdelay = 0
 	damfactor = 1.2
@@ -20,7 +20,7 @@
 	animname = "stab"
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 25
+	penfactor = PEN_MEDIUM
 	chargetime = 0
 	clickcd = CLICK_CD_FAST
 	item_d_type = "stab"
@@ -30,11 +30,8 @@
 	blade_class = BCLASS_BLUNT
 	icon_state = "inbash"
 	attack_verb = list("bashes", "strikes")
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	item_d_type = "blunt"
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_WEAK
 
 /datum/intent/lord_electrocute
 	name = "electrocute"
@@ -56,31 +53,25 @@
 	attack_verb = list("punches", "clocks")
 	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	clickcd = CLICK_CD_FAST
 	damfactor = 1.1
 	swingdelay = 0
 	icon_state = "inpunch"
 	item_d_type = "blunt"
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_WEAK
 
 /datum/intent/knuckles/smash
 	name = "smash"
 	blade_class = BCLASS_SMASH
 	attack_verb = list("smashes")
 	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	damfactor = 1.35
 	clickcd = CLICK_CD_MELEE
 	swingdelay = 8
 	intent_intdamage_factor = 1.35
 	icon_state = "insmash"
 	item_d_type = "blunt"
-	//We want chipping, m'lord.
-	blunt_chipping = TRUE
-	blunt_chip_strength = BLUNT_CHIP_STRONG
 /// INTENT DATUMS	^
 
 /obj/item/rogueweapon/lordscepter
@@ -874,19 +865,19 @@
 	damfactor = 1.2
 	swingdelay = 8
 	clickcd = CLICK_CD_MELEE
-	penfactor = 35
+	penfactor = PEN_HEAVY
 
 /datum/intent/claw/lunge/steel
 	damfactor = 1.2
 	swingdelay = 12
 	clickcd = CLICK_CD_HEAVY
-	penfactor = 35
+	penfactor = PEN_HEAVY
 
 /datum/intent/claw/lunge/gronn
 	damfactor = 1.1
 	swingdelay = 5
 	clickcd = 10
-	penfactor = 45
+	penfactor = PEN_HEAVY
 
 /datum/intent/claw/cut
 	name = "cut"
@@ -898,19 +889,19 @@
 	item_d_type = "slash"
 
 /datum/intent/claw/cut/iron
-	penfactor = 20
+	penfactor = PEN_MEDIUM
 	swingdelay = 8
 	damfactor = 1.4
 	clickcd = CLICK_CD_HEAVY
 
 /datum/intent/claw/cut/steel
-	penfactor = 10
+	penfactor = PEN_MEDIUM
 	swingdelay = 4
 	damfactor = 1.3
 	clickcd = CLICK_CD_HEAVY
 
 /datum/intent/claw/cut/gronn
-	penfactor = 30
+	penfactor = PEN_MEDIUM
 	swingdelay = 0
 	damfactor = 1.1
 	clickcd = CLICK_CD_MELEE
@@ -923,7 +914,7 @@
 	blade_class = BCLASS_CHOP
 	reach = 1
 	swingdelay = 15
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	damfactor = 2.5
 	clickcd = CLICK_CD_HEAVY
 	no_early_release = TRUE

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -13,12 +13,12 @@
 	item_d_type = "slash"
 
 /datum/intent/sword/cut/militia
-	penfactor = 30
+	penfactor = PEN_LIGHT
 	damfactor = 1.2
 	chargetime = 0.2
 
 /datum/intent/sword/chop/militia
-	penfactor = 50
+	penfactor = PEN_MEDIUM
 	chargetime = 0.5
 	swingdelay = 0
 	damfactor = 1.0
@@ -30,7 +30,7 @@
 	animname = "stab"
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 20
+	penfactor = PEN_LIGHT
 	chargetime = 0
 	swingdelay = 0
 	item_d_type = "stab"
@@ -46,7 +46,7 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	swingdelay = 0
 	damfactor = 1
 	item_d_type = "blunt"
@@ -58,7 +58,7 @@
 	desc = "Strike the opponent from above with the true edge of the sword and penetrate light armour."
 	attack_verb = list("masterfully tears", "artfully slits", "adroitly hacks")
 	damfactor = 1.01
-	penfactor = 50
+	penfactor = PEN_LIGHT
 
 /datum/intent/sword/thrust/long/master
 	name = "stoccato"
@@ -92,7 +92,7 @@
 	desc = "Grip the dull portion of your longsword with either hand and use it as leverage to deliver precise, powerful strikes that can dig into gaps in plate and push past maille."
 	attack_verb = list("goes into a half-sword stance and skewers", "enters a half-sword stance and impales")
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 80
+	penfactor = PEN_HEAVY
 	clickcd = 12
 	swingdelay = 10
 	damfactor = 0.86
@@ -132,7 +132,7 @@
 	blade_class = BCLASS_PEEL
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	swingdelay = 0
 	damfactor = 0.05
 	item_d_type = "slash"
@@ -150,7 +150,7 @@
 	animname = "chop"
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
-	penfactor = 30
+	penfactor = PEN_LIGHT
 	swingdelay = 8
 	damfactor = 1.0
 	item_d_type = "slash"
@@ -159,10 +159,10 @@
 	damfactor = 0.9
 
 /datum/intent/sword/cut/falx
-	penfactor = 20
+	penfactor = PEN_LIGHT
 
 /datum/intent/sword/chop/falx
-	penfactor = 40
+	penfactor = PEN_MEDIUM
 
 /datum/intent/sword/cut/krieg
 	clickcd = 10
@@ -869,7 +869,7 @@
 
 /datum/intent/sword/thrust/exe
 	swingdelay = 4	//Slight delay to stab; big and heavy.
-	penfactor = BLUNT_DEFAULT_PENFACTOR //Flat tip? I don't know, man. This intent is won't penetrate anything but it damages armor more.
+	penfactor = PEN_NONE //Flat tip? I don't know, man. This intent is won't penetrate anything but it damages armor more.
 	intent_intdamage_factor = 1.3 //This is basically like getting hit by a mace.
 
 /obj/item/rogueweapon/sword/long/exe/astrata
@@ -1026,7 +1026,7 @@
 /datum/intent/sword/thrust/short
 	clickcd = 8
 	damfactor = 1.1
-	penfactor = 30
+	penfactor = PEN_LIGHT
 
 /obj/item/rogueweapon/sword/iron/messer
 	name = "hunting sword"
@@ -1090,7 +1090,7 @@
 /datum/intent/sword/cut/sabre
 	clickcd = 8			//Faster than sword by 4
 	damfactor = 1.25	//Better than rapier (Base is 1.1 for swords)
-	penfactor = 10		//Very slight buff to pen on cut mode. Still weaker than sword-chop mode.
+	penfactor = PEN_NONE		//Very slight buff to pen on cut mode. Still weaker than sword-chop mode.
 
 /datum/intent/sword/thrust/sabre
 	clickcd = 9			//Fast but just shy of being as good as a rapier by 1.
@@ -1116,7 +1116,7 @@
 	attack_verb = list("masterfully cuts", "deftly slits", "quarts")
 	clickcd = 7
 	damfactor = 1.25
-	penfactor = 55
+	penfactor = PEN_MEDIUM
 
 /datum/intent/effect/daze/freisabre
 	name = "uszkodzić"
@@ -1322,7 +1322,7 @@
 /datum/intent/sword/thrust/rapier
 	clickcd = 8
 	damfactor = 1.1
-	penfactor = 30
+	penfactor = PEN_MEDIUM
 
 /obj/item/rogueweapon/sword/rapier/dec
 	name = "decorated rapier"

--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -38,7 +38,7 @@
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
 	recovery = 7
-	penfactor = 30
+	penfactor = PEN_LIGHT
 	reach = 3
 	icon_state = "inlash"
 	item_d_type = "slash"
@@ -52,7 +52,7 @@
 	chargetime = 0
 	recovery = 10
 	damfactor = 1.1
-	penfactor = 20
+	penfactor = PEN_LIGHT
 	reach = 2
 	icon_state = "incrack"
 	item_d_type = "slash"
@@ -66,7 +66,7 @@
 	chargetime = 0
 	recovery = 5
 	damfactor = 1.2							//No range, gets bonus damage - using this even on weak SHOULD let you get perma-scars then.
-	penfactor = BLUNT_DEFAULT_PENFACTOR		//No pen cus punishment intent.
+	penfactor = PEN_NONE		//No pen cus punishment intent.
 	reach = 1								//No range, cus not meant to be a flat-out combat intent.
 	icon_state = "inpunish"
 	item_d_type = "slash"
@@ -75,7 +75,7 @@
 /datum/intent/whip/crack/blunt
 	name = "bludgen"
 	blade_class = BCLASS_BLUNT
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	recovery = 6
 	damfactor = 1.2 	//20% bonus because no pen, and it doesn't get smash crits.
 	reach = 2			//Less range than a normal whip by 1 compared to crack.

--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -39,7 +39,7 @@
 	name = "bolt"
 	damage = 70
 	damage_type = BRUTE
-	armor_penetration = 50
+	armor_penetration = PEN_HEAVY
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "bolt_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/bolt
@@ -53,11 +53,11 @@
 
 /obj/projectile/bullet/reusable/bolt/aalloy
 	damage = 40
-	armor_penetration = 30
+	armor_penetration = PEN_MEDIUM
 
 /obj/projectile/bullet/reusable/bolt/paalloy
 	damage = 50
-	armor_penetration = 35
+	armor_penetration = PEN_HEAVY
 
 /obj/projectile/bullet/reusable/bolt/on_hit(atom/target)
 	. = ..()
@@ -132,7 +132,7 @@
 	damage = 20
 	damage_type = BRUTE
 	npc_damage_mult = 2
-	armor_penetration = 10
+	armor_penetration = PEN_NONE
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow
@@ -170,7 +170,7 @@
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/iron
 
 	damage = 40
-	armor_penetration = 0
+	armor_penetration = PEN_LIGHT
 	embedchance = 30
 	npc_damage_mult = 2
 
@@ -178,7 +178,7 @@
 	name = "decrepit broadhead arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/iron/aalloy
 	damage = 20
-	armor_penetration = 0
+	armor_penetration = PEN_LIGHT
 
 /obj/projectile/bullet/reusable/arrow/steel
 	name = "bodkin arrow"
@@ -186,7 +186,7 @@
 
 	accuracy = 75
 	damage = 25
-	armor_penetration = 45
+	armor_penetration = PEN_HEAVY
 	embedchance = 80
 	speed = 0.6
 	npc_damage_mult = 3
@@ -195,7 +195,7 @@
 	name = "decrepit bodkin arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/steel/paalloy
 	damage = 15
-	armor_penetration = 25
+	armor_penetration = PEN_HEAVY
 
 // POISON AMMO
 
@@ -403,7 +403,7 @@
 /obj/projectile/bullet/reusable/arrow/orc
 	damage = 20
 	damage_type = BRUTE
-	armor_penetration = 25
+	armor_penetration = PEN_LIGHT
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/stone
@@ -417,7 +417,7 @@
 /obj/projectile/bullet/reusable/arrow/ancient
 	damage = 10
 	damage_type = BRUTE
-	armor_penetration = 25
+	armor_penetration = PEN_LIGHT
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/stone
@@ -432,7 +432,7 @@
 	name = "stone"
 	damage = 25
 	damage_type = BRUTE
-	armor_penetration = 30
+	armor_penetration = PEN_NONE
 	icon = 'icons/roguetown/items/natural.dmi'
 	icon_state = "stone1"
 	ammo_type = /obj/item/natural/stone
@@ -499,7 +499,7 @@
 	icon_state = "ijavelin"
 	wlength = WLENGTH_NORMAL
 	w_class = WEIGHT_CLASS_BULKY
-	armor_penetration = 40					//Redfined because.. it's not a weapon, it's an 'arrow' basically.
+	armor_penetration = PEN_MEDIUM					//Redfined because.. it's not a weapon, it's an 'arrow' basically.
 	max_integrity = 50						//Breaks semi-easy, stops constant re-use. 
 	wdefense = 3							//Worse than a spear
 	thrown_bclass = BCLASS_STAB				//Knives are slash, lets try out stab and see if it's too strong in terms of wounding.
@@ -522,7 +522,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/javelin/steel
 	force = 16
-	armor_penetration = 50
+	armor_penetration = PEN_HEAVY
 	name = "steel javelin"
 	desc = "A tool used for centuries, as early as recorded history. This one is tipped with a steel head; perfect for piercing armor!"
 	icon_state = "javelin"
@@ -544,7 +544,7 @@
 	icon_state = "sjavelin"
 	is_silver = TRUE
 	throwforce = 25							//Less than steel because it's.. silver. Good at killing vampires/WW's still.
-	armor_penetration = 60
+	armor_penetration = PEN_HEAVY
 	thrown_bclass = BCLASS_PICK				//Bypasses crit protection better than stabbing. Makes it better against heavy-targets.
 	smeltresult = /obj/item/ingot/silver
 
@@ -614,7 +614,7 @@
 	desc = "If you're reading this: duck."
 	damage = 25
 	damage_type = BRUTE
-	armor_penetration = 0
+	armor_penetration = PEN_NONE
 	npc_damage_mult = 2
 	icon = 'icons/roguetown/items/natural.dmi'
 	icon_state = "stone1"
@@ -646,7 +646,7 @@
 	desc = "If you're reading this: duck."
 	damage = 25
 	damage_type = BRUTE
-	armor_penetration = 0
+	armor_penetration = PEN_NONE
 	icon = 'icons/roguetown/items/natural.dmi'
 	icon_state = "stone1"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet
@@ -676,7 +676,7 @@
 /obj/projectile/bullet/reusable/sling_bullet/stone
 	name = "stone sling bullet"
 	damage = 30 //proper stones are better
-	armor_penetration = 0
+	armor_penetration = PEN_NONE
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/stone
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "musketball_proj"
@@ -684,7 +684,7 @@
 /obj/projectile/bullet/reusable/sling_bullet/aalloy
 	name = "decrepit sling bullet"
 	damage = 15 
-	armor_penetration = 0
+	armor_penetration = PEN_NONE
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/aalloy
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "musketball_proj"
@@ -692,7 +692,7 @@
 /obj/projectile/bullet/reusable/sling_bullet/paalloy
 	name = "ancient sling bullet"
 	damage = 30
-	armor_penetration = 30
+	armor_penetration = PEN_NONE
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/paalloy
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "musketball_proj"
@@ -700,7 +700,7 @@
 /obj/projectile/bullet/reusable/sling_bullet/iron
 	name = "iron sling bullet"
 	damage = 30
-	armor_penetration = 30
+	armor_penetration = PEN_NONE
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/iron
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "musketball_proj"

--- a/code/game/objects/items/rogueweapons/ranged/firearms/firearm_ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/firearms/firearm_ammo.dm
@@ -15,7 +15,7 @@
 /obj/projectile/bullet/firearm
 	name = "PARENT SMOKEPOWDER PROJECTILE"
 	damage = 80//Do you see how infrequently these things fire...
-	armor_penetration = 50//Lowered from 90 so heavy plate/heavy padding actually mitigate firearm damage instead of being treated as nothing.
+	armor_penetration = PEN_HEAVY//Lowered from 90 so heavy plate/heavy padding actually mitigate firearm damage instead of being treated as nothing.
 	range = 30//We want this to go a few screens. Regardless.
 	embedchance = 100//Yessir.
 	speed = 0.1//Take a guess.

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -78,7 +78,7 @@
 	icon_state = "inbash"
 	hitsound = list('sound/combat/shieldbash_wood.ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	item_d_type = "blunt"
 
 /datum/intent/shield/bash/metal
@@ -103,7 +103,7 @@
 	attack_verb = list("smashes")
 	icon_state = "insmash"
 	hitsound = list('sound/combat/shieldbash_wood.ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = PEN_NONE
 	damfactor = 1.5
 	swingdelay = 10
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -65,7 +65,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throw_speed = 2
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	armor_penetration = 100
+	armor_penetration = PEN_NONE
 	attack_verb = list("bludgeoned", "whacked", "disciplined")
 	resistance_flags = FLAMMABLE
 

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -365,7 +365,7 @@
 /obj/projectile/magic/frostbolt/wall_projectile
 	speed = 6
 	damage = 20
-	armor_penetration = 5
+	armor_penetration = PEN_NONE
 
 /obj/structure/trap/wall_projectile/acidsplash
 	name = "acid plate trap"

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
@@ -201,7 +201,7 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "chop"
 	hitsound = "genslash"
-	penfactor = 20
+	penfactor = PEN_LIGHT
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"
@@ -214,12 +214,12 @@
 	desc = "A powerful smash of savage muscle that deals normal damage, but can throw a standing opponent back and slow them down, based on your strength. Ineffective below 10 strength. Slowdown & Knockback scales to your Strength up to 15 (1 - 5 tiles). Cannot be used consecutively more than every 5 seconds on the same target. Prone targets halve the knockback distance."
 	icon_state = "insmash"
 	chargetime = 1
-	penfactor = 0
+	penfactor = PEN_NONE
 
 /datum/intent/simple/gnoll_cut
 	name = "cutting claw"
 	hitsound = "genslash"
-	penfactor = 40
+	penfactor = PEN_MEDIUM
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -150,7 +150,7 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "chop"
 	hitsound = "genslash"
-	penfactor = 50
+	penfactor = PEN_HEAVY
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"
@@ -162,7 +162,7 @@
 	desc = "A powerful, smash of lycan muscle that deals normal damage but can throw a standing opponent back and slow them down, based on your strength. Ineffective below 10 strength. Slowdown & Knockback scales to your Strength up to 15 (1 - 5 tiles). Cannot be used consecutively more than every 5 seconds on the same target. Prone targets halve the knockback distance."
 	icon_state = "insmash"
 	chargetime = 1
-	penfactor = 60
+	penfactor = PEN_HEAVY
 
 /obj/item/rogueweapon/werewolf_claw
 	name = "Verevolf Claw"
@@ -177,7 +177,7 @@
 	force = 25
 	block_chance = 0
 	wdefense = 2
-	armor_penetration = 15
+	armor_penetration = PEN_NONE
 	associated_skill = /datum/skill/combat/unarmed
 	wlength = WLENGTH_NORMAL
 	wbalance = WBALANCE_HEAVY

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -542,11 +542,12 @@ BLIND     // can't see anything
 		return examine_text
 
 	var/str
+	// Blunt gets no tier name - it's absorbed, never checked against weapon PEN.
 	str += "[colorgrade_rating("🔨 BLUNT ", armor.blunt, elaborate = TRUE)] | "
-	str += "[colorgrade_rating("🪓 SLASH ", armor.slash, elaborate = TRUE)]"
+	str += "[colorgrade_rating("🪓 SLASH ", armor.slash, elaborate = TRUE, d_type = "slash")]"
 	str += "<br>"
-	str += "[colorgrade_rating("🗡️ STAB ", armor.stab, elaborate = TRUE)] | "
-	str += "[colorgrade_rating("🏹 PIERCE ", armor.piercing, elaborate = TRUE)] "
+	str += "[colorgrade_rating("🗡️ STAB ", armor.stab, elaborate = TRUE, d_type = "stab")] | "
+	str += "[colorgrade_rating("🏹 PIERCE ", armor.piercing, elaborate = TRUE, d_type = "piercing")] "
 
 	if(showcrits && prevent_crits)
 		str += "<br>———————————————<br>"

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -648,7 +648,7 @@
 	desc = "A heavy set of hardened robes, lined with fur. The leather is composed of several creatures that were notably difficult to fell by arrow. A proof or rangership among many."
 	icon_state = "hatanga"
 	item_state = "hatanga"
-	armor = list("blunt" = 90, "slash" = 30, "stab" = 40, "piercing" = 60, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_MEDIUM, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_STAB, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_PICK, BCLASS_TWIST)
 	max_integrity = 300
 	sellprice = 100
@@ -1041,7 +1041,7 @@
 	desc = "Very simple and crude protection for the chest. Ancient fighters once used similar gear, with better quality..."
 	icon_state = "copperchest"
 	max_integrity = 150
-	armor = list("blunt" = 75, "slash" = 75, "stab" = 75, "piercing" = 40, "fire" = 0, "acid" = 0)	//idk what this armor is but I ain't making a define for it
+	armor = list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)	//idk what this armor is but I ain't making a define for it
 	smeltresult = /obj/item/ingot/copper
 	body_parts_covered = CHEST
 	armor_class = ARMOR_CLASS_LIGHT
@@ -1737,7 +1737,7 @@
 	name = "woad elven plate"
 	desc = "Woven by song and tool of the oldest elven druids. It still creaks and weeps with forlorn reminiscence of a bygone era. It looks like only Elves can fit in it."
 	allowed_race = list(/datum/species/elf/wood, /datum/species/human/halfelf, /datum/species/elf/dark, /datum/species/elf)
-	armor = list("blunt" = 100, "slash" = 20, "stab" = 130, "piercing" = 40, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_BLUNT, BCLASS_TWIST, BCLASS_PICK, BCLASS_SMASH)
 	body_parts_covered = COVERAGE_FULL
 	icon = 'icons/roguetown/clothing/special/race_armor.dmi'
@@ -1769,7 +1769,7 @@
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
 	body_parts_covered = COVERAGE_FULL
-	armor = list("blunt" = 35, "slash" = 75, "stab" = 40, "piercing" = 20, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_MEDIUM, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT, BCLASS_CHOP)
 	blocksound = SOFTHIT
 	blade_dulling = DULLING_BASHCHOP
@@ -1795,7 +1795,7 @@
 	desc = "A dobo robe with a red tassel. Leather inlays are sewn in."
 	icon_state = "eastsuit2"
 	item_state = "eastsuit2"
-	armor = list("blunt" = 50, "slash" = 90, "stab" = 60, "piercing" = 30, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	max_integrity = 200
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/crafteast/outlaw
@@ -1825,7 +1825,7 @@
 	icon_state = "eastsuit1"
 	item_state = "eastsuit1"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_armor.dmi'
-	armor = list("blunt" = 50, "slash" = 90, "stab" = 60, "piercing" = 30, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	max_integrity = 200
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit/light
@@ -1839,7 +1839,7 @@
 	desc = "Flower-styled robes, said to have been infused with magical protection. The Merchant Guild says that this is from the southern Kazengite region."
 	icon_state = "eastsuit4"
 	item_state = "eastsuit4"
-	armor = list("blunt" = 50, "slash" = 90, "stab" = 60, "piercing" = 30, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	max_integrity = 300
 	sellprice = 25
 
@@ -1898,7 +1898,7 @@
 	item_state = "carapace"
 	blocksound = PLATEHIT
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
-	armor = list("blunt" = 70, "slash" = 85, "stab" = 60, "piercing" = 60, "fire" = 25, "acid" = 0) //Slightly above carapace cuirass
+	armor = list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE) //Slightly above carapace cuirass
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	max_integrity = 225
 	allowed_sex = list(MALE, FEMALE)
@@ -1920,7 +1920,7 @@
 	slot_flags = ITEM_SLOT_ARMOR
 	name = "carapace cuirass"
 	desc = "Vest styled watery shell chest armor sewn in layers."
-	armor = list("blunt" = 60, "slash" = 80, "stab" = 60, "piercing" = 50, "fire" = 20, "acid" = 0) //Below Brigandine, Above Hardened Leather
+	armor = list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_NONE) //Below Brigandine, Above Hardened Leather
 	body_parts_covered = CHEST|GROIN|VITALS
 	icon_state = "carapacecuirass"
 	item_state = "carapacecuirass"

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -1655,7 +1655,7 @@
 			user.change_stat("constitution", 2)
 			user.change_stat("endurance", 2)
 			user.change_stat("speed", 2)
-			armor = getArmor("blunt" = 100, "slash" = 100, "stab" = 100, "piercing" = 100, "fire" = 50, "acid" = 0)
+			armor = getArmor("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_HEAVY, "acid" = DR_NONE)
 		else
 			to_chat(user, span_notice("I feel an evil power about that necklace..."))
 			armor = getArmor("blunt" = 0, "slash" = 0, "stab" = 0, "piercing" = 0, "fire" = 0, "acid" = 0)
@@ -1675,7 +1675,7 @@
 		user.change_stat("speed", -2)
 	else
 		to_chat(user, span_notice("Strange, I don't feel that power anymore..."))
-		armor = getArmor("blunt" = 100, "slash" = 100, "stab" = 100, "piercing" = 100, "fire" = 50, "acid" = 0)
+		armor = getArmor("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_HEAVY, "fire" = DR_HEAVY, "acid" = DR_NONE)
 
 /obj/item/clothing/suit/roguetown/armor/plate/blkknight
 	slot_flags = ITEM_SLOT_ARMOR

--- a/code/modules/clothing/rogueclothes/dummy_items.dm
+++ b/code/modules/clothing/rogueclothes/dummy_items.dm
@@ -76,7 +76,7 @@
 	animname = "cut"
 	blade_class = BCLASS_CUT
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
-	penfactor = 0
+	penfactor = PEN_NONE
 	chargetime = 0
 	swingdelay = 0
 	clickcd = 8
@@ -89,7 +89,7 @@
 	animname = "chop"
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	damfactor = 1.5
 	swingdelay = 5
 	clickcd = 10
@@ -100,7 +100,7 @@
 	icon_state = "ingrab"
 	attack_verb = list("digs", "impales")
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 90
+	penfactor = PEN_BSTEEL
 	clickcd = 15
 	swingdelay = 0
 	damfactor = 1.3
@@ -111,7 +111,7 @@
 	icon_state = "inpick"
 	attack_verb = list("stabs", "impales")
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 75
+	penfactor = PEN_BSTEEL
 	clickcd = 14
 	swingdelay = 12
 	damfactor = 1.1

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -179,7 +179,7 @@
 	icon_state = "shalal"
 	item_state = "shalal"
 	sewrepair = TRUE
-	armor = list("blunt" = 25, "slash" = 20, "stab" = 25, "piercing" = 0, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_NONE, "fire" = DR_NONE, "acid" = DR_NONE)
 
 /obj/item/clothing/shoes/roguetown/boots/leather
 	name = "leather boots"
@@ -238,7 +238,7 @@
 /obj/item/clothing/shoes/roguetown/boots/leather/elven_boots
 	name = "woad elven boots"
 	desc = "The living trunks still blossom in the spring. They let water through, but it is never cold."
-	armor = list("blunt" = 100, "slash" = 10, "stab" = 100, "piercing" = 20, "fire" = 0, "acid" = 0) //Resistant to blunt and stab, but very weak to slash.
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE) //Resistant to blunt and stab, but very weak to slash.
 	prevent_crits = list(BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST, BCLASS_PICK)
 	icon = 'icons/roguetown/clothing/special/race_armor.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
@@ -456,7 +456,7 @@
 /obj/item/clothing/shoes/roguetown/boots/leather/elven_boots
 	name = "woad elven boots"
 	desc = "The living trunks still blossom in the spring. They let water through, but it is never cold."
-	armor = list("blunt" = 100, "slash" = 10, "stab" = 100, "piercing" = 20, "fire" = 0, "acid" = 0) //Resistant to blunt and stab, but very weak to slash.
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE) //Resistant to blunt and stab, but very weak to slash.
 	prevent_crits = list(BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST, BCLASS_PICK)
 	icon = 'icons/roguetown/clothing/special/race_armor.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
@@ -487,7 +487,7 @@
 	color = null
 	blocksound = PLATEHIT
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
-	armor = list("blunt" = 30, "slash" = 50, "stab" = 60, "piercing" = 30, "fire" = 30, "acid" = 0) //Sidegrade to plated boots. (Worse for most situation, better against fire or pierce.)
+	armor = list("blunt" = DR_MEDIUM, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE) //Sidegrade to plated boots. (Worse for most situation, better against fire or pierce.)
 	max_integrity = 225
 	anvilrepair = null
 	smeltresult = /obj/item/ash

--- a/code/modules/clothing/rogueclothes/gloves.dm
+++ b/code/modules/clothing/rogueclothes/gloves.dm
@@ -348,7 +348,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
 	icon_state = "welfhand"
 	item_state = "welfhand"
-	armor = list("blunt" = 100, "slash" = 10, "stab" = 110, "piercing" = 20, "fire" = 0, "acid" = 0)//Resistant to blunt and stab, super weak to slash.
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)//Resistant to blunt and stab, super weak to slash.
 	prevent_crits = list(BCLASS_BLUNT, BCLASS_SMASH, BCLASS_PICK)
 	resistance_flags = FIRE_PROOF
 	blocksound = SOFTHIT
@@ -401,7 +401,7 @@
 	name = "carapace gauntlets"
 	desc = "Strong carapace plated gauntlets to sink your pincers into."
 	icon_state = "carapace_gauntlets"
-	armor = list("blunt" = 60, "slash" = 50, "stab" = 50, "piercing" = 30, "fire" = 30, "acid" = 0) //Around chain level
+	armor = list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE) //Around chain level
 	max_integrity = 225
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT)
 	resistance_flags = null

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -135,7 +135,7 @@
 	alternate_worn_layer  = 8.9 //On top of helmet
 	body_parts_covered = HEAD|HAIR|EARS|NECK|MOUTH|NOSE
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
-	armor = list("blunt" = 20, "slash" = 20, "stab" = 15, "piercing" = 1, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	dynamic_hair_suffix = ""
 	edelay_type = 1
 	adjustable = CAN_CADJUST
@@ -2353,7 +2353,7 @@
 	name = "woad elven helm"
 	desc = "An assembly of woven trunk, kept alive by ancient song, now twisted and warped for battle and scorn."
 	body_parts_covered = FULL_HEAD | NECK
-	armor = list("blunt" = 100, "slash" = 20, "stab" = 110, "piercing" = 40, "fire" = 0, "acid" = 0)//Resistant to blunt & stab, but very weak to slash.
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)//Resistant to blunt & stab, but very weak to slash.
 	prevent_crits = list(BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST, BCLASS_PICK)
 	icon = 'icons/roguetown/clothing/special/race_armor.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/race_armor.dmi'
@@ -2486,7 +2486,7 @@
 	desc = "A reinforced bamboo hat."
 	icon_state = "easthat"
 	item_state = "easthat"
-	armor = list("blunt" = 70, "slash" = 80, "stab" = 65, "piercing" = 40, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST)
 	max_integrity = 150
 	blocksound = SOFTHIT
@@ -2595,7 +2595,7 @@
 	body_parts_covered = HEAD|HAIR
 	icon_state = "carapacecap"
 	item_state = "carapacecap"
-	armor = list("blunt" = 60, "slash" = 50, "stab" = 40, "piercing" = 30, "fire" = 10, "acid" = 0) //Around Leather level
+	armor = list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_LIGHT, "acid" = DR_NONE) //Around Leather level
 	prevent_crits = list(BCLASS_CUT, BCLASS_CHOP, BCLASS_BLUNT)
 	max_integrity = 150
 	anvilrepair = null
@@ -2614,7 +2614,7 @@
 	block2add = FOV_BEHIND
 	icon_state = "carapacehelm"
 	item_state = "carapacehelm"
-	armor = list("blunt" = 70, "slash" = 70, "stab" = 50, "piercing" = 40, "fire" = 15, "acid" = 0) //Around Hardened Leather level.
+	armor = list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_LIGHT, "acid" = DR_NONE) //Around Hardened Leather level.
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST)
 	max_integrity = 200
 	anvilrepair = null
@@ -2737,7 +2737,7 @@
 	icon_state = "psylongest"
 	item_state = "psylongest"
 	emote_environment = 3
-	armor = list("blunt" = 200, "slash" = 200, "stab" = 200, "piercing" = 200, "fire" = 200, "acid" = 200) //ENDVRE, admin shitspawn item..
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_BSTEEL, "stab" = DBLOCK_BSTEEL, "piercing" = DBLOCK_BSTEEL, "fire" = DR_ULTRA, "acid" = DR_ULTRA) //ENDVRE, admin shitspawn item..
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST)
 	max_integrity = 9999
 	body_parts_covered = FULL_HEAD

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -518,7 +518,7 @@
 	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HIP
 	armor = ARMOR_PADDED_BAD
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
-	armor = list("blunt" = 10, "slash" = 10, "stab" = 10, "piercing" = 10, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	anvilrepair = /datum/skill/craft/carpentry
 
 /obj/item/clothing/mask/rogue/facemask/cheap_kitsune
@@ -529,7 +529,7 @@
 	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HIP
 	armor = ARMOR_PADDED_BAD
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
-	armor = list("blunt" = 10, "slash" = 10, "stab" = 10, "piercing" = 10, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_LIGHT, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	anvilrepair = /datum/skill/craft/carpentry
 
 /obj/item/clothing/mask/rogue/shepherd

--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -643,7 +643,7 @@
 	icon_state = "eastpants1"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_pants.dmi'
 	max_integrity = 130
-	armor = list("blunt" = 50, "slash" = 90, "stab" = 60, "piercing" = 30, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT)
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	flags_inv = HIDECROTCH
@@ -658,7 +658,7 @@
 	desc = "Weird pants typically worn by the destitute in Kazengun. Or, those looking to make a fashion statement."
 	icon_state = "eastpants2"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_pants.dmi'
-	armor = list("blunt" = 50, "slash" = 90, "stab" = 60, "piercing" = 30, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT)
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	flags_inv = HIDECROTCH
@@ -681,7 +681,7 @@
 	smeltresult = /obj/item/ash
 	sewrepair = TRUE
 	anvilrepair = null
-	armor = list("blunt" = 70, "slash" = 60, "stab" = 50, "piercing" = 30, "fire" = 30, "acid" = 0) //Around Hardened leather
+	armor = list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_MEDIUM, "acid" = DR_NONE) //Around Hardened leather
 	max_integrity = 225
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)
 	blocksound = PLATEHIT

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -721,7 +721,7 @@
 	desc = "It's styled into the shapes of clouds. You shudder as the ink moves and condenses into areas where the skin is struck."
 	resistance_flags = FIRE_PROOF
 	icon_state = "easttats"
-	armor = list("blunt" = 30, "slash" = 50, "stab" = 50, "piercing" = 20, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_MEDIUM, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR
 	body_parts_covered = COVERAGE_FULL

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -246,7 +246,7 @@
 	body_parts_covered = ARMS
 	icon_state = "carapace_bracers"
 	item_state = "carapace_bracers"
-	armor = list("blunt" = 70, "slash" = 70, "stab" = 60, "piercing" = 50, "fire" = 30, "acid" = 0)
+	armor = list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	blocksound = PLATEHIT
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgebearer.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgebearer.dm
@@ -254,10 +254,10 @@
 	layer_repair = 2
 
 	layer_max = list(
-		"blunt" = 40,
-		"slash" = 200,
-		"stab" = 200,
-		"piercing" = 100,
+		"blunt" = DR_MEDIUM,
+		"slash" = DBLOCK_BSTEEL,
+		"stab" = DBLOCK_BSTEEL,
+		"piercing" = DBLOCK_HEAVY,
 	)
 
 	hits_to_shred = list(
@@ -275,17 +275,10 @@
 	)
 
 	hits_per_layer = list(
-		"200"	= 3,
-		"100" 	= 3,
-		"90" 	= 3,
-		"80" 	= 5,
-		"70" 	= 5,
-		"60" 	= 5,
-		"50"	= 10,
-		"40"	= 10,
-		"30"	= 20,
-		"20"	= 30,
-		"10"	= 50,
+		"4"	= 3,
+		"3" = 8,
+		"2" = 12,
+		"1" = 25,
 	)
 
 	repair_items = list(/obj/machinery/anvil)
@@ -310,25 +303,17 @@
 	)
 
 	layer_max = list(
-		"blunt" = 40,
-		"slash" = 200,
-		"stab" = 200,
-		"piercing" = 90,
+		"blunt" = DR_MEDIUM,
+		"slash" = DBLOCK_BSTEEL,
+		"stab" = DBLOCK_BSTEEL,
+		"piercing" = DBLOCK_HEAVY,
 	)
 
 	hits_per_layer = list(
-		"200"	= 2,
-		"100" 	= 2,
-		"90" 	= 2,
-		"80" 	= 2,
-		"70" 	= 2,
-		"60" 	= 2,
-		"50"	= 2,
-		"40"	= 2,
-		"30"	= 4,
-		"20"	= 20,
-		"10"	= 30,
+		"4"	= 2, // Limbs shred faster than the chest.
+		"3" = 4,
+		"2" = 6,
+		"1" = 12,
 	)
 
-	shred_amt = 20	//Limbs lose 2 grades per layer shred, but also repair 4.
-	layer_repair = 2
+	layer_repair = 2	//Limbs repair 2 tiers per fix.

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgekeeper.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgekeeper.dm
@@ -170,10 +170,10 @@
 	layer_repair = 2
 
 	layer_max = list(
-		"blunt" = 60, // Bit more blunt
-		"slash" = 200,
-		"stab" = 200,
-		"piercing" = 100,
+		"blunt" = DR_HEAVY, // Bit more blunt
+		"slash" = DBLOCK_BSTEEL,
+		"stab" = DBLOCK_BSTEEL,
+		"piercing" = DBLOCK_HEAVY,
 	)
 
 	hits_to_shred = list(
@@ -187,21 +187,14 @@
 		"blunt" = 1,
 		"slash" = 1,
 		"stab" = 1,
-		"piercing" = 3, // Half as Succeptible to ranged attacks. 
+		"piercing" = 3, // Half as Succeptible to ranged attacks.
 	)
 
 	hits_per_layer = list(
-		"200"	= 5, // Two more at max.
-		"100" 	= 4,
-		"90" 	= 4,
-		"80" 	= 6,
-		"70" 	= 6, // One more up to 70% 
-		"60" 	= 5,
-		"50"	= 10,
-		"40"	= 10,
-		"30"	= 20,
-		"20"	= 30,
-		"10"	= 50,
+		"4"	= 5, // Top layer holds longest.
+		"3" = 10,
+		"2" = 15,
+		"1" = 25,
 	)
 
 	repair_items = list(/obj/machinery/anvil)
@@ -226,25 +219,17 @@
 	)
 
 	layer_max = list(
-		"blunt" = 60, //Bit more Blunt
-		"slash" = 200,
-		"stab" = 200,
-		"piercing" = 100, //Bit more Pierce
+		"blunt" = DR_HEAVY, //Bit more Blunt
+		"slash" = DBLOCK_BSTEEL,
+		"stab" = DBLOCK_BSTEEL,
+		"piercing" = DBLOCK_HEAVY, //Bit more Pierce
 	)
 
 	hits_per_layer = list(
-		"200"	= 3, 
-		"100" 	= 3,
-		"90" 	= 3, 
-		"80" 	= 3, // One more hit for LIMBS.
-		"70" 	= 3,
-		"60" 	= 3,
-		"50"	= 3,
-		"40"	= 3,
-		"30"	= 4,
-		"20"	= 20,
-		"10"	= 30,
+		"4"	= 3, // Limbs shred faster than the chest.
+		"3" = 6,
+		"2" = 8,
+		"1" = 15,
 	)
 
-	shred_amt = 20	//Limbs lose 2 grades per layer shred, but also repair 4.
-	layer_repair = 2
+	layer_repair = 2	//Limbs repair 2 tiers per fix.

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/trollslayer.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/trollslayer.dm
@@ -205,7 +205,7 @@
     name = "rough skin"
     desc = ""
     icon_state = null
-    armor = list("blunt" = 30, "slash" = 30, "stab" = 30, "piercing" = 30, "fire" = 15, "acid" = 15)
+    armor = list("blunt" = DR_MEDIUM, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_LIGHT, "acid" = DR_LIGHT)
     prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
     blocksound = SOFTHIT
     blade_dulling = DULLING_BASHCHOP

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -350,7 +350,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 
-		if(HAS_TRAIT(H, TRAIT_INTELLECTUAL) || H.get_skill_level(H, /datum/skill/craft/blacksmithing) >= SKILL_EXP_EXPERT)
+		if(HAS_TRAIT(H, TRAIT_INTELLECTUAL) || H.get_skill_level(/datum/skill/craft/blacksmithing) >= SKILL_LEVEL_EXPERT)
 			is_smart = TRUE	//Most of this is determining integrity of objects + seeing multiple layers. 
 		if(((H?.STAINT - 10) + round((H?.STAPER - 10) / 2) + H.get_skill_level(/datum/skill/misc/reading)) < 0 && !is_smart)
 			is_stupid = TRUE
@@ -408,9 +408,12 @@
 	//suit/armor
 	if(wear_armor && !(SLOT_ARMOR in obscured))
 		var/str = "[m3] [wear_armor.generate_tooltip(wear_armor.get_examine_string(user), showcrits = (is_normal || is_smart))]. "
-		if(is_smart || is_normal)
+		// Anyone not outright stupid reads the damage state, same as every other slot.
+		// Gating this on is_normal left average examiners (who are neither stupid nor normal)
+		// with no readout at all.
+		if(!is_stupid)
 			str += wear_armor.integrity_check(is_smart)
-		else if (is_stupid)
+		else
 			if(istype(wear_armor, /obj/item/clothing/suit/roguetown/armor))
 				var/obj/item/clothing/suit/roguetown/armor/examined_armor = wear_armor
 				switch(examined_armor.armor_class)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -24,15 +24,18 @@
 	used = get_best_worn_armor(def_zone, d_type)
 	if(used)
 		protection = used.armor.getRating(d_type)
+		// Protection comes from the BEST covering item, but the hit physically lands on the
+		// OUTERMOST covering item - that's what gets peeled, sounds off, and loses integrity.
+		var/obj/item/clothing/struck = get_outermost_worn_armor(def_zone, d_type) || used
 		if(!blade_dulling)
 			blade_dulling = BCLASS_BLUNT
 		if(blade_dulling == BCLASS_PEEL)	//Peel shouldn't be dealing any damage through armor, or to armor itself.
-			used.peel_coverage(def_zone, peeldivisor, src)
+			struck.peel_coverage(def_zone, peeldivisor, src)
 			damage = 0
 			if(def_zone == BODY_ZONE_CHEST)
 				purge_peel(99)
-		if(used.blocksound)
-			playsound(loc, get_armor_sound(used.blocksound, blade_dulling), 100)
+		if(struck.blocksound)
+			playsound(loc, get_armor_sound(struck.blocksound, blade_dulling), 100)
 		var/intdamage = damage
 		// Tier-based integrity damage. protection is the armor's tier.
 		if(d_type in ARMOR_DR_ABSORB_TYPES)
@@ -55,7 +58,7 @@
 					intdamage = damage * PEN_PASSTHROUGH_PROJ_MORE
 		if(intdamfactor != 1)
 			intdamage *= intdamfactor
-		if(istype(used_weapon) && used_weapon.is_silver && ((used.smeltresult in list(/obj/item/ingot/aaslag, /obj/item/ingot/aalloy, /obj/item/ingot/purifiedaalloy)) || used.GetComponent(/datum/component/cursed_item)))
+		if(istype(used_weapon) && used_weapon.is_silver && ((struck.smeltresult in list(/obj/item/ingot/aaslag, /obj/item/ingot/aalloy, /obj/item/ingot/purifiedaalloy)) || struck.GetComponent(/datum/component/cursed_item)))
 			// Blessed silver delivers more int damage against "cursed" alloys, see component for multiplier values
 			var/datum/component/silverbless/bless = used_weapon.GetComponent(/datum/component/silverbless)
 			if(bless.is_blessed)
@@ -64,7 +67,7 @@
 		var/tempo_bonus = get_tempo_bonus(TEMPO_TAG_ARMOR_INTEGFACTOR)
 		if(tempo_bonus)
 			intdamage *= tempo_bonus
-		used.take_damage(intdamage, damage_flag = d_type, sound_effect = FALSE, armor_penetration = 100)
+		struck.take_damage(intdamage, damage_flag = d_type, sound_effect = FALSE, armor_penetration = 100)
 	if(physiology)
 		protection += physiology.armor.getRating(d_type)
 	return protection
@@ -833,6 +836,25 @@
 
 	for(var/obj/item/I as anything in torn_items)
 		I.take_damage(damage_amount, damage_type, damage_flag, 0)
+
+/// Returns the OUTERMOST worn item covering def_zone with any rating for d_type and integrity
+/// left. This is the item that takes integrity damage on a hit - protection still comes from
+/// get_best_worn_armor(). Order is an explicit outer->inner layer model: a ward shell first,
+/// then cloak/back, the armor slot, then extremity slots, then the shirt slot BEFORE pants
+/// (a hauberk hangs over the legs), with natural skin armor damaged last of all.
+/mob/living/carbon/human/proc/get_outermost_worn_armor(def_zone, d_type)
+	var/list/layer_order = list(arcyne_ward_armor, cloak, backr, backl, wear_armor, head, wear_mask, wear_neck, gloves, shoes, wear_shirt, wear_pants, wear_wrists, glasses, ears, belt, s_store, wear_ring, skin_armor)
+	for(var/bp in layer_order)
+		if(!bp || !istype(bp, /obj/item/clothing))
+			continue
+		var/obj/item/clothing/C = bp
+		if(!zone2covered(def_zone, C.body_parts_covered_dynamic))
+			continue
+		if(C.max_integrity && C.obj_integrity <= 0)
+			continue
+		if(C.armor.getRating(d_type) > 0)
+			return C
+	return null
 
 /// Helper proc that returns the worn item ref that has the highest rating covering the def_zone (targeted zone) for the d_type (damage type)
 /mob/living/carbon/human/proc/get_best_worn_armor(def_zone, d_type)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -87,7 +87,9 @@
 		if(bp && istype(bp , /obj/item/clothing))
 			var/obj/item/clothing/C = bp
 			if(zone2covered(def_zone, C.body_parts_covered_dynamic))
-				if(C.obj_integrity > 1)
+				// obj_broken check: clothing breaks at 10% integrity, well above 1 —
+				// without it, broken armor (gnoll hide etc.) kept blocking crits.
+				if(C.obj_integrity > 1 && !C.obj_broken)
 					if(d_type in C.prevent_crits)
 						return TRUE
 
@@ -107,7 +109,7 @@
 		if(bp && istype(bp , /obj/item/clothing))
 			var/obj/item/clothing/C = bp
 			if(zone2covered(def_zone, C.body_parts_covered_dynamic))
-				if(C.obj_integrity > 1)
+				if(C.obj_integrity > 1 && !C.obj_broken)
 					if(bclass in C.prevent_crits)
 						if(!best_armor)
 							best_armor = C

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -1,9 +1,9 @@
-/mob/living/carbon/human/getarmor(def_zone, type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor, used_weapon)
+/mob/living/carbon/human/getarmor(def_zone, type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor, used_weapon, pen_info)
 	var/armorval = 0
 	var/organnum = 0
 
 	if(def_zone)
-		return checkarmor(def_zone, type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor, used_weapon)
+		return checkarmor(def_zone, type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor, used_weapon, pen_info)
 		//If a specific bodypart is targetted, check how that bodypart is protected and return the value.
 
 	//If you don't specify a bodypart, it checks ALL my bodyparts for protection, and averages out the values
@@ -13,7 +13,7 @@
 	return (armorval/max(organnum, 1))
 
 
-/mob/living/carbon/human/proc/checkarmor(def_zone, d_type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor = 1, obj/item/used_weapon)
+/mob/living/carbon/human/proc/checkarmor(def_zone, d_type, damage, armor_penetration = PEN_NONE, blade_dulling, peeldivisor, intdamfactor = 1, obj/item/used_weapon, pen_info)
 	if(!d_type)
 		return 0
 	if(isbodypart(def_zone))
@@ -34,15 +34,27 @@
 		if(used.blocksound)
 			playsound(loc, get_armor_sound(used.blocksound, blade_dulling), 100)
 		var/intdamage = damage
-		// Penetrative damage deals significantly less to the armor. Tentative.
-		if((damage + armor_penetration) > protection && d_type != "blunt")
-			intdamage = (damage + armor_penetration) - protection
+		// Tier-based integrity damage. protection is the armor's tier.
+		if(d_type in ARMOR_DR_ABSORB_TYPES)
+			// Blunt: armor eats the DR-reduced share. Lower tier -> more integrity lost.
+			if(protection > 0)
+				intdamage = damage * (1 / (1 + 0.2 * protection))
+		else if(d_type in ARMOR_DR_PIERCE_TYPES)
+			// Fire/Acid: armor takes the portion it blocked (what didn't reach HP).
+			if(protection > 0)
+				intdamage = damage * (1 - (1 / (1 + 0.2 * protection)))
+		else
+			// Penetration types (slash, stab, piercing): pen tier vs armor tier.
+			if(d_type != "piercing")
+				if(armor_penetration >= protection)
+					intdamage = damage * (1 - (pen_info * PEN_PASSTHROUGH_RATIO))
+			else
+				if(armor_penetration == protection)
+					intdamage = damage * PEN_PASSTHROUGH_PROJ_EQUAL
+				else if(armor_penetration > protection)
+					intdamage = damage * PEN_PASSTHROUGH_PROJ_MORE
 		if(intdamfactor != 1)
 			intdamage *= intdamfactor
-		if(d_type == "blunt")
-			if(used.armor?.getRating("blunt") > 0)
-				var/bluntrating = used.armor.getRating("blunt")
-				intdamage -= intdamage * ((bluntrating / 2) / 100)	//Half of the blunt rating reduces blunt damage taken by %-age.
 		if(istype(used_weapon) && used_weapon.is_silver && ((used.smeltresult in list(/obj/item/ingot/aaslag, /obj/item/ingot/aalloy, /obj/item/ingot/purifiedaalloy)) || used.GetComponent(/datum/component/cursed_item)))
 			// Blessed silver delivers more int damage against "cursed" alloys, see component for multiplier values
 			var/datum/component/silverbless/bless = used_weapon.GetComponent(/datum/component/silverbless)

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -470,42 +470,32 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 	var/str
 	if(isnull(rating))
 		rating = 0
+	// Armor is tier-based now (0-5): DBLOCK 0-4 for slash/stab/piercing, DR 0-5 for blunt.
+	// Layered readouts can sum above a single tier, so 6+ collapses to S+.
 	switch(rating)
-		if(0 to 9)
+		if(0)
 			var/color = "#f81a1a"
-			str = elaborate ? "<font color = '[color]'>[input] (F)</font>" : "<font color = '[color]'>[input] (F)</font>"
-		if(10 to 19)
-			var/color = "#680d0d"
-			str = elaborate ? "<font color = '[color]'>[input] (D)</font>" : "<font color = '[color]'>[input] (D)</font>"
-		if(20 to 39)
+			str = "<font color = '[color]'>[input] (F)</font>"
+		if(1)
 			var/color = "#753e11"
-			str = elaborate ? "<font color = '[color]'>[input] (D+)</font>" : "<font color = '[color]'>[input] (D+)</font>"
-		if(40 to 49)
+			str = "<font color = '[color]'>[input] (D)</font>"
+		if(2)
 			var/color = "#c0a739"
-			str = elaborate ? "<font color = '[color]'>[input] (C)</font>" : "<font color = '[color]'>[input] (C to C+)</font>"
-		if(50 to 59)
-			var/color = "#e3e63c"
-			str = elaborate ? "<font color = '[color]'>[input] (C+)</font>" : "<font color = '[color]'>[input] (C to C+)</font>"
-		if(60 to 69)
+			str = "<font color = '[color]'>[input] (C)</font>"
+		if(3)
 			var/color = "#425c33"
-			str = elaborate ? "<font color = '[color]'>[input] (B)</font>" : "<font color = '[color]'>[input] (B to B+)</font>"
-		if(70 to 79)
-			var/color = "#1a9c00"
-			str = elaborate ? "<font color = '[color]'>[input] (B+)</font>" : "<font color = '[color]'>[input] (B to B+)</font>"
-		if(80 to 89)
+			str = "<font color = '[color]'>[input] (B)</font>"
+		if(4)
 			var/color = "#0fe021"
-			str = elaborate ? "<font color = '[color]'>[input] (A)</font>" : "<font color = '[color]'>[input] (A to A+)</font>"
-		if(90 to 99)
-			var/color = "#ffffff"
-			str = elaborate ? "<font color = '[color]'>[input] (A+)</font>" : "<font color = '[color]'>[input] (A to A+)</font>"
-		if(100)
+			str = "<font color = '[color]'>[input] (A)</font>"
+		if(5)
 			var/color = "#339dff"
 			str = "<font color = '[color]'>[input] (S)</font>"
-		if(101 to 200)
+		if(6 to INFINITY)
 			var/color = "#c757af"
 			str = "<font color = '[color]'>[input] (S+)</font>"
 		else
-			str = "[input] (Under 0 or above 200! Contact coders.)"
+			str = "[input] (Invalid tier! Contact coders.)"
 	return str
 
 /*/proc/defense_report(var/obj/item/clothing/C, var/stupid, var/normal, var/smart, var/stupid_string)

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -402,7 +402,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 							for(var/exposed in coverage_exposed)
 								str += "<b>[exposed]</b>: <font color = '#770404'><b>EXPOSED!</B></font><br>"
 					for(var/thing in coverage)
-						str += "<b>[thing]</b> LAYERS: <b>[coverage[thing]]</b> | [colorgrade_rating("", blunt_max[thing], TRUE)] | [colorgrade_rating("", slash_max[thing], TRUE)] | [colorgrade_rating("", stab_max[thing], TRUE)] | [colorgrade_rating("", piercing_max[thing], TRUE)] <br><font color = '#a35252'>[crit_weakness[thing]]</font><br>"
+						str += "<b>[thing]</b> LAYERS: <b>[coverage[thing]]</b> | [colorgrade_rating("", blunt_max[thing], TRUE)] | [colorgrade_rating("", slash_max[thing], TRUE, "slash")] | [colorgrade_rating("", stab_max[thing], TRUE, "stab")] | [colorgrade_rating("", piercing_max[thing], TRUE, "piercing")] <br><font color = '#a35252'>[crit_weakness[thing]]</font><br>"
 					dat += str
 				else
 					dat += "<b><center>I don't know! Just hit them!</center></b>"
@@ -466,36 +466,51 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 	return ..() //end of this massive fucking chain. TODO: make the hud chain not spooky. - Yeah, great job doing that. - I made it worse sorry guys.
 
 //Sorry colorblind folks...
-/proc/colorgrade_rating(input, rating, elaborate = FALSE)
+// Pass d_type ("blunt", "slash", "stab", "piercing", "fire", "acid") to label with the armor's
+// actual tier name instead of a letter grade. Without it we can't tell DR from DBLOCK, so we
+// fall back to the letter.
+/proc/colorgrade_rating(input, rating, elaborate = FALSE, d_type)
 	var/str
 	if(isnull(rating))
 		rating = 0
 	// Armor is tier-based now (0-5): DBLOCK 0-4 for slash/stab/piercing, DR 0-5 for blunt.
 	// Layered readouts can sum above a single tier, so 6+ collapses to S+.
+	var/grade
 	switch(rating)
 		if(0)
-			var/color = "#f81a1a"
-			str = "<font color = '[color]'>[input] (F)</font>"
+			grade = "F"
 		if(1)
-			var/color = "#753e11"
-			str = "<font color = '[color]'>[input] (D)</font>"
+			grade = "D"
 		if(2)
-			var/color = "#c0a739"
-			str = "<font color = '[color]'>[input] (C)</font>"
+			grade = "C"
 		if(3)
-			var/color = "#425c33"
-			str = "<font color = '[color]'>[input] (B)</font>"
+			grade = "B"
 		if(4)
-			var/color = "#0fe021"
-			str = "<font color = '[color]'>[input] (A)</font>"
+			grade = "A"
 		if(5)
-			var/color = "#339dff"
-			str = "<font color = '[color]'>[input] (S)</font>"
+			grade = "S"
 		if(6 to INFINITY)
-			var/color = "#c757af"
-			str = "<font color = '[color]'>[input] (S+)</font>"
+			grade = "S+"
 		else
-			str = "[input] (Invalid tier! Contact coders.)"
+			return "[input] (Invalid tier! Contact coders.)"
+	var/label = d_type ? "[armor_tier_name(rating, d_type)] / [grade]" : grade
+	var/color
+	switch(rating)
+		if(0)
+			color = "#f81a1a"
+		if(1)
+			color = "#753e11"
+		if(2)
+			color = "#c0a739"
+		if(3)
+			color = "#425c33"
+		if(4)
+			color = "#0fe021"
+		if(5)
+			color = "#339dff"
+		else
+			color = "#c757af"
+	str = "<font color = '[color]'>[input] ([label])</font>"
 	return str
 
 /*/proc/defense_report(var/obj/item/clothing/C, var/stupid, var/normal, var/smart, var/stupid_string)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1793,7 +1793,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		else
 			user.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text)
 
-	var/armor_block = H.run_armor_check(selzone, I.d_type, "", "",pen, damage = Iforce, blade_dulling=bladec, peeldivisor = user.used_intent.peel_divisor, intdamfactor = used_intfactor, used_weapon = I)
+	var/pen_info_check = get_pen_info(H, user, H.get_best_worn_armor(selzone, I.d_type), selzone, I.d_type, pen, I)
+	var/armor_block = H.run_armor_check(selzone, I.d_type, "", "",pen, damage = Iforce, blade_dulling=bladec, peeldivisor = user.used_intent.peel_divisor, intdamfactor = used_intfactor, used_weapon = I, pen_info = pen_info_check)
 
 	var/nodmg = FALSE
 
@@ -1808,15 +1809,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			if(I)
 				I.take_damage(1, BRUTE, I.d_type)
 				SEND_SIGNAL(I, COMSIG_ITEM_ATTACKBY_BLOCKED, H, user, I.damtype, def_zone) // attack was blocked by armor or other variables
-				//Blunt chipping, no matter what. Assuming it has damage. This is done after armour damage.
-				if(user.used_intent.blunt_chipping)//We won't check for blunt. Just that it's able. For funny reasons.
-					var/blunt_chip_block = H.run_armor_check(selzone, "blunt", armor_penetration = 80)
-					H.apply_damage(Iforce * user.used_intent.blunt_chip_strength, BRUTE, def_zone, blunt_chip_block)
-					H.next_attack_msg += " <span class='warning'>and yet the force punches through!</span>"
 		if(!nodmg)
 			if(I)
 				SEND_SIGNAL(I, COMSIG_ITEM_ATTACKBY_SUCCESS, H, user, Iforce * weakness, I.damtype, def_zone) // attack was not blocked by armor or other variables
-			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, (Iforce * weakness) * ((100-(armor_block+armor))/100), user, selzone, crit_message = TRUE, weapon = I)
+			// Tier system: armor_block is ABSOLUTE damage blocked (was a %). Racial armor kept consistent with apply_damage.
+			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, max((Iforce * weakness) - armor_block - armor, 0), user, selzone, crit_message = TRUE, weapon = I)
 			if(should_embed_weapon(crit_wound, I))
 				var/can_impale = TRUE
 				if(!affecting)
@@ -1919,7 +1916,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 /datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE, spread_damage = FALSE)
 	SEND_SIGNAL(H, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone)
 	var/hit_percent = 1
-	damage = max(damage-blocked+armor,0)
+	damage = max(damage-blocked-armor,0)
 //	var/hit_percent =  (100-(blocked+armor))/100
 	hit_percent = (hit_percent * (100-H.physiology.damage_resistance))/100
 	var/atom/movable/screen/zone_sel/zone_sel

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1812,8 +1812,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(!nodmg)
 			if(I)
 				SEND_SIGNAL(I, COMSIG_ITEM_ATTACKBY_SUCCESS, H, user, Iforce * weakness, I.damtype, def_zone) // attack was not blocked by armor or other variables
-			// Tier system: armor_block is ABSOLUTE damage blocked (was a %). Racial armor kept consistent with apply_damage.
-			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, max((Iforce * weakness) - armor_block - armor, 0), user, selzone, crit_message = TRUE, weapon = I)
+			// Tier system: armor_block is ABSOLUTE damage blocked (was a %). Racial `armor` is still a
+			// PERCENT (gnoll/werewolf 30) — subtracting it flat zeroed most hits, kept consistent with apply_damage.
+			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, max((Iforce * weakness) - armor_block, 0) * (100 - armor) / 100, user, selzone, crit_message = TRUE, weapon = I)
 			if(should_embed_weapon(crit_wound, I))
 				var/can_impale = TRUE
 				if(!affecting)
@@ -1916,8 +1917,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 /datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE, spread_damage = FALSE)
 	SEND_SIGNAL(H, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone)
 	var/hit_percent = 1
-	damage = max(damage-blocked-armor,0)
-//	var/hit_percent =  (100-(blocked+armor))/100
+	// `blocked` is ABSOLUTE damage (tier armor system); racial `armor` is a PERCENT reduction
+	// (gnoll/werewolf = 30). Subtracting the percent flat made 30-armor races immune to any
+	// hit under 30 force — stab/cut/pierce dealt literally nothing even with the hide broken.
+	damage = max(damage - blocked, 0) * (100 - armor) / 100
 	hit_percent = (hit_percent * (100-H.physiology.damage_resistance))/100
 	var/atom/movable/screen/zone_sel/zone_sel
 	if(def_zone && H.client && H.hud_used && H.hud_used.zone_select)

--- a/code/modules/mob/living/carbon/human/species_types/species/harpy.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/harpy.dm
@@ -214,7 +214,7 @@
 	icon_state = null
 	body_parts_covered = FEET|LEGS
 	body_parts_inherent = FEET|LEGS
-	armor = list("blunt" = 90, "slash" = 90, "stab" = 50, "piercing" = 20, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_CHOP, BCLASS_STAB, BCLASS_BLUNT, BCLASS_TWIST)
 	blocksound = SOFTHIT
 	blade_dulling = DULLING_BASHCHOP

--- a/code/modules/mob/living/carbon/human/species_types/species/lamia.dm
+++ b/code/modules/mob/living/carbon/human/species_types/species/lamia.dm
@@ -304,7 +304,7 @@
 	// still covers the leg/foot subtarget zones.
 	body_parts_covered = FEET|LEGS|TAIL_LAMIA
 	body_parts_inherent = FEET|LEGS|TAIL_LAMIA
-	armor = list("blunt" = 90, "slash" = 90, "stab" = 50, "piercing" = 20, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_CHOP, BCLASS_STAB, BCLASS_BLUNT, BCLASS_TWIST)
 	blocksound = SOFTHIT
 	blade_dulling = DULLING_BASHCHOP

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/bear.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/bear.dm
@@ -113,7 +113,7 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "cut"
 	hitsound = "genslash"
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/cabbit.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/cabbit.dm
@@ -103,7 +103,7 @@
 	attack_verb = list("claws", "cuts", "scratches")
 	animname = "cut"
 	hitsound = "genslash"
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/cat.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/cat.dm
@@ -106,7 +106,7 @@
 	attack_verb = list("claws", "cuts", "scratches")
 	animname = "cut"
 	hitsound = "genslash"
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/dendormole.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/dendormole.dm
@@ -119,7 +119,7 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "cut"
 	hitsound = "genslash"
-	penfactor = 15
+	penfactor = PEN_LIGHT
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/mirecrawler.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/mirecrawler.dm
@@ -165,7 +165,7 @@
 	attack_verb = list("bites, chomps")
 	animname = "cut"
 	hitsound = "genslash"
-	penfactor = 5
+	penfactor = PEN_NONE
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air with its fangs!"

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/spider.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/spider.dm
@@ -112,7 +112,7 @@
 	attack_verb = list("bites", "pierces", "impales")
 	animname = "stab"
 	hitsound = "genslash"
-	penfactor = 20
+	penfactor = PEN_LIGHT
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "bites the air!"

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/vernard.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/vernard.dm
@@ -109,7 +109,7 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "cut"
 	hitsound = "genslash"
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/volf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/volf.dm
@@ -115,7 +115,7 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "cut"
 	hitsound = "genslash"
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,31 +1,137 @@
 
-/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "blunt", absorb_text = null, soften_text = null, armor_penetration, penetrated_text, damage, blade_dulling, peeldivisor, intdamfactor, used_weapon = null)
-	var/armor = getarmor(def_zone, attack_flag, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor, used_weapon)
+// Tier-based armor. Returns ABSOLUTE damage blocked (subtracted from damage by apply_damage), NOT a percentage.
+// armor_tier and armor_penetration are both tier values. Three resolution families:
+//   ARMOR_DR_ABSORB_TYPES (blunt): tier > 0 -> all HP damage absorbed; the hit lands on integrity (in checkarmor).
+//   ARMOR_DR_PIERCE_TYPES (fire, acid): DR reduces damage, but the reduced damage still reaches HP.
+//   DBLOCK (slash, stab, piercing): weapon PEN tier vs armor DBLOCK tier, scaled by pen_info "dots".
+// "Fully blocked" returns block_damage * 10 so damage - blocked clamps to 0 in apply_damage.
+/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "blunt", absorb_text = null, soften_text = null, armor_penetration = PEN_NONE, penetrated_text, damage, blade_dulling, peeldivisor, intdamfactor, used_weapon = null, pen_info)
+	var/armor_tier = getarmor(def_zone, attack_flag, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor, used_weapon, pen_info)
 
-	//the if "armor" check is because this is used for everything on /living, including humans
-	if(armor > 0 && armor_penetration)
-		armor = max(0, armor - armor_penetration)
-		if(penetrated_text)
-			to_chat(src, span_danger("[penetrated_text]"))
-//		else
-//			to_chat(src, span_danger("My armor was penetrated!"))
-	else if(armor >= 100)
-		if(absorb_text)
-			to_chat(src, span_notice("[absorb_text]"))
-//		else
-//			to_chat(src, span_notice("My armor absorbs the blow!"))
-	else if(armor > 0)
-		if(soften_text)
-			to_chat(src, span_warning("[soften_text]"))
-//		else
-//			to_chat(src, span_warning("My armor softens the blow!"))
+	var/block_damage = damage || 999
+	var/blocked = 0
+	if(attack_flag in ARMOR_DR_ABSORB_TYPES)
+		// Blunt: armor absorbs all HP damage. Integrity damage is handled in checkarmor.
+		if(armor_tier > 0)
+			blocked = block_damage
+	else if(attack_flag in ARMOR_DR_PIERCE_TYPES)
+		// Fire/Acid: DR reduces damage, but the reduced damage still reaches HP.
+		if(armor_tier > 0)
+			var/dr_mult = 1 / (1 + 0.2 * armor_tier)
+			blocked = block_damage * (1 - dr_mult)
+	else
+		// Penetration: weapon PEN tier vs armor DBLOCK tier.
+		if(attack_flag != "piercing")
+			if(armor_tier > 0)
+				if(armor_penetration >= armor_tier)
+					if(pen_info)
+						blocked = block_damage * (1 - (pen_info * PEN_PASSTHROUGH_RATIO))
+					if(penetrated_text)
+						to_chat(src, span_danger("[penetrated_text]"))
+				else
+					// Fully blocked.
+					blocked = block_damage * 10
+					if(absorb_text)
+						to_chat(src, span_notice("[absorb_text]"))
+		else
+			// Piercing/projectiles: absent most pen_info data, so use fixed fractions.
+			if(armor_tier > 0)
+				if(armor_penetration == armor_tier)
+					blocked = block_damage * (1 - PEN_PASSTHROUGH_PROJ_EQUAL) // 20% through
+					if(penetrated_text)
+						to_chat(src, span_danger("[penetrated_text]"))
+				else if(armor_penetration > armor_tier)
+					blocked = block_damage * (1 - PEN_PASSTHROUGH_PROJ_MORE) // 80% through
+					if(penetrated_text)
+						to_chat(src, span_danger("[penetrated_text]"))
+				else
+					// Fully blocked.
+					blocked = block_damage * 10
+					if(absorb_text)
+						to_chat(src, span_notice("[absorb_text]"))
+
+	// A badly dulled sharp weapon can't pen anything.
+	if(used_weapon && isitem(used_weapon))
+		var/obj/item/I = used_weapon
+		if(I.sharpness && I.max_blade_int && !(attack_flag in ARMOR_DR_ABSORB_TYPES))
+			var/dullness_ratio = I.blade_int / I.max_blade_int
+			if(dullness_ratio <= SHARPNESS_TIER2_THRESHOLD)
+				blocked = block_damage * 10
+
 	if(mob_timers[MT_INVISIBILITY] > world.time)
 		mob_timers[MT_INVISIBILITY] = world.time
 		update_sneak_invis(reset = TRUE)
-	return armor
+	return blocked
 
+#define SHARPNESS_PENALTY_RATIO_ONE 0.7
+#define SHARPNESS_PENALTY_RATIO_TWO 0.6
+#define SHARPNESS_PENALTY_RATIO_THREE 0.5
+#define SHARPNESS_PENALTY_RATIO_FOUR 0.4
 
-/mob/living/proc/getarmor(def_zone, type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor, used_weapon)
+// Computes pen "dots": (pen - armor) + relevant stat above 10 + sharpness bonus/penalty + damfactor bonus, clamped 1..CAP.
+/proc/get_pen_info(mob/living/carbon/human/target, mob/living/attacker, obj/item/clothing/used_armor, def_zone, d_type, armor_pen, obj/item/I)
+	if(!target || !def_zone || !d_type || !armor_pen || !ishuman(target))
+		return 1
+	var/pen_total = armor_pen
+	var/protection
+	if(!used_armor)
+		used_armor = target.get_best_worn_armor(def_zone, d_type)
+	if(used_armor)
+		protection = used_armor.armor.getRating(d_type)
+	pen_total -= protection
+	var/balance_bonus = 0
+	var/sharpness_bonus = 0
+	var/damfactor_bonus = 0
+	if(I)
+		var/use_bonus = TRUE
+		if(I.sharpness && I.max_blade_int) // IS_BLUNT is 0, so this is falsy for blunt weapons.
+			var/dullness_ratio = I.blade_int / I.max_blade_int
+			if(attacker.used_intent.damfactor != 1)
+				damfactor_bonus += floor(((attacker?.used_intent?.damfactor) - 1) * 10)
+			if(dullness_ratio > SHARPNESS_TIER1_THRESHOLD)
+				sharpness_bonus += 1
+				use_bonus = TRUE
+			else if(dullness_ratio < SHARPNESS_TIER2_THRESHOLD + 0.1)
+				use_bonus = FALSE
+				if(damfactor_bonus > 0)
+					damfactor_bonus = 0
+			else
+				if(dullness_ratio < SHARPNESS_PENALTY_RATIO_ONE)
+					if(damfactor_bonus > 0)
+						damfactor_bonus = max(damfactor_bonus - 1, 0)
+				if(dullness_ratio <= SHARPNESS_PENALTY_RATIO_TWO)
+					sharpness_bonus -= 1
+				if(dullness_ratio <= SHARPNESS_PENALTY_RATIO_THREE)
+					if(damfactor_bonus > 0)
+						damfactor_bonus = max(damfactor_bonus - 1, 0)
+				if(dullness_ratio <= SHARPNESS_PENALTY_RATIO_FOUR)
+					sharpness_bonus -= 1
+		if(use_bonus)
+			switch(I.wbalance)
+				if(WBALANCE_HEAVY)
+					balance_bonus = (attacker.STASTR - 10) + 2
+				if(WBALANCE_NORMAL)
+					balance_bonus = (attacker.STASTR - 10)
+				if(WBALANCE_SWIFT)
+					balance_bonus = (attacker.STASPD - 10)
+	else
+		balance_bonus = (attacker.STASTR - 10) // Unarmed, probably.
+	// Don't let a sharpness malus net us MORE pen than our stats alone would have.
+	if(abs(balance_bonus) <= abs(sharpness_bonus) && sharpness_bonus <= 0 && balance_bonus >= 0)
+		balance_bonus = 0
+		sharpness_bonus = 0
+	pen_total += balance_bonus
+	pen_total += sharpness_bonus
+	// Callers use this while already inside the penning branch, so floor it at 1.
+	pen_total = clamp(pen_total, 1, PEN_PASSTHROUGH_CAP)
+	return pen_total
+
+#undef SHARPNESS_PENALTY_RATIO_ONE
+#undef SHARPNESS_PENALTY_RATIO_TWO
+#undef SHARPNESS_PENALTY_RATIO_THREE
+#undef SHARPNESS_PENALTY_RATIO_FOUR
+
+/mob/living/proc/getarmor(def_zone, type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor, used_weapon, pen_info)
 	return 0
 
 //this returns the mob's protection against eye damage (number between -1 and 2) from bright lights

--- a/code/modules/mob/living/simple_animal/hostile/bosses/baroness.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/baroness.dm
@@ -237,7 +237,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = 'sound/combat/hits/bladed/genchop (1).ogg'
 	chargetime = 15
-	penfactor = 20
+	penfactor = PEN_LIGHT
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/bosses/lich_boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/lich_boss.dm
@@ -305,7 +305,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = 'sound/combat/hits/bladed/genchop (1).ogg'
 	chargetime = 20
-	penfactor = 25
+	penfactor = PEN_MEDIUM
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/deepone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/deepone.dm
@@ -105,7 +105,7 @@
 	animname = "cut"
 	hitsound = 'sound/combat/hits/bladed/smallslash (1).ogg'
 	clickcd = DEEPONE_ATTACK_SPEED
-	penfactor = 5
+	penfactor = PEN_NONE
 	chargetime = 2
 /datum/intent/simple/claw/deepone_boss
 	attack_verb = list("smashes", "slams")
@@ -113,5 +113,5 @@
 	animname = "cut"
 	hitsound = 'sound/combat/hits/blunt/metalblunt (1).ogg'
 	clickcd = DEEPONE_ATTACK_SPEED
-	penfactor = 5
+	penfactor = PEN_NONE
 	chargetime = 2

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/imp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/imp.dm
@@ -59,7 +59,7 @@
 	damage = 20
 	damage_type = BURN
 	nodamage = FALSE
-	armor_penetration = 0
+	armor_penetration = PEN_NONE
 	flag = "magic"
 	hitsound = 'sound/blank.ogg'
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/obelisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/obelisk.dm
@@ -89,7 +89,7 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = 'sound/combat/hits/onstone/wallhit.ogg'
 	chargetime = 0
-	penfactor = 20
+	penfactor = PEN_LIGHT
 	swingdelay = 0
 	candodge = TRUE
 	canparry = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/voiddragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/voiddragon.dm
@@ -109,7 +109,7 @@ It will also call down lightning strikes from the sky, and fling people with it'
 	animname = "cut"
 	blade_class = BCLASS_CHOP
 	hitsound = "genslash"
-	penfactor = 60
+	penfactor = PEN_HEAVY
 	damfactor = 40
 	candodge = TRUE
 	canparry = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/roguetown/haunt.dm
+++ b/code/modules/mob/living/simple_animal/hostile/roguetown/haunt.dm
@@ -239,7 +239,7 @@
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	chargetime = 0
-	penfactor = 10
+	penfactor = PEN_NONE
 	swingdelay = 8
 	clickcd = HAUNT_ATTACK_SPEED
 

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -178,7 +178,7 @@
 	animname = "cut"
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	chargetime = 2
-	penfactor = 5
+	penfactor = PEN_NONE
 	swingdelay = 8
 
 /obj/item/skull

--- a/code/modules/mob/living/simple_animal/rogue/creacher/demon.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/demon.dm
@@ -155,5 +155,5 @@
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	chargetime = 0
-	penfactor = 10
+	penfactor = PEN_NONE
 	swingdelay = 3

--- a/code/modules/mob/living/simple_animal/rogue/creacher/dragger.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/dragger.dm
@@ -155,6 +155,6 @@
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	chargetime = 0
-	penfactor = 10
+	penfactor = PEN_NONE
 	swingdelay = 3
 	clickcd = DRAGGER_ATTACK_SPEED

--- a/code/modules/mob/living/simple_animal/rogue/creacher/trolls/troll.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/trolls/troll.dm
@@ -182,4 +182,4 @@
 	
 /datum/intent/unarmed/claw/troll
 	clickcd = TROLL_ATTACK_SPEED
-	penfactor = 20
+	penfactor = PEN_LIGHT

--- a/code/modules/mob/living/simple_animal/rogue/creacher/trolls/trollaxe.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/trolls/trollaxe.dm
@@ -27,5 +27,5 @@
 	hitsound = "genchop"
 	blade_class = BCLASS_CHOP
 	chargetime = 20
-	penfactor = 10
+	penfactor = PEN_NONE
 	swingdelay = 3

--- a/code/modules/mob/living/special_intents.dm
+++ b/code/modules/mob/living/special_intents.dm
@@ -318,7 +318,7 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 		if(full_pen && armor_block)
 			armor_block = 0		//You block NOTHING, sir!
 		if(HT.apply_damage(dam, W.damtype, affecting, armor_block))
-			affecting.bodypart_attacked_by(bclass, dam, howner, armor = armor_block, crit_message = TRUE, weapon = W)
+			affecting.bodypart_attacked_by(bclass, dam, howner, crit_message = TRUE, weapon = W)
 			msg += "<b> It pierces through to their flesh!</b>"
 			playsound(HT, pick(W.hitsound), 80, TRUE)
 	else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -85,7 +85,7 @@
 	var/nodamage = FALSE //Determines if the projectile will skip any damage inflictions
 	var/flag = "piercing" //Defines what armor to use when it hits things. Setting this to "blunt" might result in unexpected behavior (i.e. knockout on hit, figure out the root causes and excise it)
 	///How much armor this projectile pierces.
-	var/armor_penetration = 0
+	var/armor_penetration = PEN_NONE
 	var/projectile_type = /obj/projectile
 	var/range = 50 //This will de-increment every step. When 0, it will deletze the projectile.
 	var/decayedRange			//stores original range

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -4,7 +4,7 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = TRUE
-	armor_penetration = 100
+	armor_penetration = PEN_NONE
 	pass_flags = PASSTABLE | PASSGRILLE
 	flag = "magic"
 	var/explode_sound = list('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg')
@@ -138,7 +138,7 @@
 	damage = 20
 	damage_type = BURN
 	nodamage = FALSE
-	armor_penetration = 0
+	armor_penetration = PEN_NONE
 	flag = "magic"
 	hitsound = 'sound/blank.ogg'
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -254,7 +254,7 @@
 	dropshrink = 0.8
 	slot_flags = null
 	resistance_flags = NONE
-	armor = list("blunt" = 25, "slash" = 20, "stab" = 15, "piercing" = 0, "fire" = 75, "acid" = 50) //Weak melee protection, because you can wear it on your head
+	armor = list("blunt" = 25, "slash" = 20, "stab" = 15, "piercing" = 0, "fire" = 75, "acid" = 50) //INTEGRITY_ARMOR - object integrity (System B), stays 0-100. Not worn protection: get_best_worn_armor() only reads /obj/item/clothing.
 	slot_equipment_priority = list( \
 		SLOT_BACK, SLOT_RING,\
 		SLOT_PANTS, SLOT_ARMOR,\

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -679,7 +679,7 @@ GLOBAL_LIST_EMPTY(divine_destruction_mobs) // Tracks mobs undergoing divine dest
 		var/obj/item/rogueweapon/weapon = source
 		estimated_damage = weapon.force
 	
-	W.upgrade(estimated_damage, 0)  // 0 armor for full pain effect
+	W.upgrade(estimated_damage)
 	
 	// Add stress event
 	living_target.add_stress(/datum/stressevent/scorch)
@@ -705,7 +705,7 @@ GLOBAL_LIST_EMPTY(divine_destruction_mobs) // Tracks mobs undergoing divine dest
 	// Apply the wound (pain only)
 	var/datum/wound/scorch/W = new()
 	affecting.add_wound(W)
-	W.upgrade(10, 0)  // Unarmed strike - less damage, less pain
+	W.upgrade(10)  // Unarmed strike - less damage
 	
 	// Add stress event
 	H.add_stress(/datum/stressevent/scorch)

--- a/code/modules/spells/spell_types/wizard/misc/magicians_brick.dm
+++ b/code/modules/spells/spell_types/wizard/misc/magicians_brick.dm
@@ -53,7 +53,7 @@
 	force = 15 // Copy pasted from real brick + 1 for neat number
 	throwforce = 20 // +2 from real brick for neat scaling
 	throw_speed = 4
-	armor_penetration = 30 // From iron tossblade
+	armor_penetration = PEN_MEDIUM // From iron tossblade
 	wdefense = 0
 	wbalance = WBALANCE_NORMAL
 	max_integrity = 50 // Don't parry with it lol

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -140,19 +140,10 @@
 	return bleed_rate
 
 /// Called after a bodypart is attacked so that wounds and critical effects can be applied
-/obj/item/bodypart/proc/bodypart_attacked_by(bclass = BCLASS_BLUNT, dam, mob/living/user, zone_precise = src.body_zone, silent = FALSE, crit_message = FALSE, armor, obj/item/weapon)
+/obj/item/bodypart/proc/bodypart_attacked_by(bclass = BCLASS_BLUNT, dam, mob/living/user, zone_precise = src.body_zone, silent = FALSE, crit_message = FALSE, obj/item/weapon)
 	if(!bclass || !dam || !owner || (owner.status_flags & GODMODE))
 		return FALSE
 	var/do_crit = TRUE
-	var/acheck_dflag
-	switch(bclass)
-		if(BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST, BCLASS_PUNCH)
-			acheck_dflag = "blunt"
-		if(BCLASS_CHOP, BCLASS_CUT, BCLASS_LASHING, BCLASS_PUNISH)
-			acheck_dflag = "slash"
-		if(BCLASS_PICK, BCLASS_STAB)
-			acheck_dflag = "stab"
-	armor = owner.run_armor_check(zone_precise, acheck_dflag, damage = 0)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
 		if(human_owner.checkcritarmor(zone_precise, bclass))
@@ -166,7 +157,7 @@
 			do_crit = FALSE
 	testing("bodypart_attacked_by() dam [dam]")
 
-	var/datum/wound/dynwound = manage_dynamic_wound(bclass, dam, armor)
+	var/datum/wound/dynwound = manage_dynamic_wound(bclass, dam)
 
 	if(do_crit)
 		var/datum/component/silverbless/psyblessed = weapon?.GetComponent(/datum/component/silverbless)
@@ -176,7 +167,7 @@
 			return crit_attempt
 	return dynwound
 
-/obj/item/bodypart/proc/manage_dynamic_wound(bclass, dam, armor)
+/obj/item/bodypart/proc/manage_dynamic_wound(bclass, dam)
 	var/woundtype
 	switch(bclass)
 		if(BCLASS_BLUNT, BCLASS_SMASH, BCLASS_PUNCH, BCLASS_TWIST)
@@ -197,14 +188,14 @@
 			return
 	var/datum/wound/dynwound = has_wound(woundtype)
 	if(!isnull(dynwound))
-		dynwound.upgrade(dam, armor)
+		dynwound.upgrade(dam)
 	else
 		if(ispath(woundtype) && woundtype)
 			if(!isnull(woundtype))
 				var/datum/wound/newwound = add_wound(woundtype)
 				dynwound = newwound
 				if(newwound && !isnull(newwound))	//don't even ask - Free
-					newwound.upgrade(dam, armor)
+					newwound.upgrade(dam)
 	return dynwound
 
 /// Behemoth of a proc used to apply a wound after a bodypart is damaged in an attack

--- a/code/modules/vampire_neu/covens/coven_powers/demonic.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/demonic.dm
@@ -175,7 +175,7 @@
 	max_integrity = 900
 	force = 6
 	wdefense = 9
-	armor_penetration = 100
+	armor_penetration = PEN_BSTEEL
 	block_chance = 20
 	associated_skill = /datum/skill/magic/blood
 	wlength = WLENGTH_NORMAL

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/abyssal_monsters.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/abyssal_monsters.dm
@@ -206,7 +206,7 @@
 	animname = "cut"
 	blade_class = BCLASS_CHOP
 	hitsound = list('modular_azurepeak/sound/mobs/abyssal/abyssal_attack.ogg','modular_azurepeak/sound/mobs/abyssal/abyssal_attack2.ogg')
-	penfactor = 30
+	penfactor = PEN_MEDIUM
 
 // EVENT mobs and mappable mobs. (USE SPARINGLY)
 /mob/living/simple_animal/hostile/rogue/dreamfiend/unbound

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -189,7 +189,7 @@
 	reach = 2
 	swingdelay = 2
 	clickcd = DRAGON_ATTACK_SPEED //It is a dragon so it bites slightly faster
-	penfactor = 60 // It is a dragon so it bites hard
+	penfactor = PEN_HEAVY // It is a dragon so it bites hard
 
 /obj/projectile/magic/aoe/dragon_breath
     name = "fire hairball"

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/minotaur.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/minotaur.dm
@@ -168,7 +168,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = "smallslash"
 	chargetime = 0
-	penfactor = 5
+	penfactor = PEN_NONE
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE
@@ -183,7 +183,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = "genchop"
 	chargetime = 10
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE

--- a/modular_azurepeak/code/modules/spells/magi2/_defines.dm
+++ b/modular_azurepeak/code/modules/spells/magi2/_defines.dm
@@ -206,13 +206,13 @@
 #define TELEPORT_MAX_NONMAGES   2
 
 // ---- Armor types used by Magi 2 ward upgrades ----
-// AP defines these via its DR_/DBLOCK_ severity constants; we hand-pick values for the
-// pilot in the same style as Emerald Summit's existing ARMOR_LEATHER/ARMOR_PLATE defines.
+// Tier values (DR_* / DBLOCK_*), matching the core armor_defines.dm migration.
 // Dragonhide trades a bit of physical protection for meaningful fire resistance.
 // Brigandine is a tough mid-tier alternative — better than leather, worse than plate.
-#define ARMOR_DRAGONHIDE list("blunt" = 50, "slash" = 50, "stab" = 40, "piercing" = 20, "fire" = 70, "acid" = 0)
-#define ARMOR_BRIGANDINE list("blunt" = 70, "slash" = 80, "stab" = 60, "piercing" = 50, "fire" = 0, "acid" = 0)
-#define ARMOR_BATHYHIDE list("blunt" = 70, "slash" = 80, "stab" = 60, "piercing" = 70, "fire" = 0, "acid" = 0)
+// Bathyhide is brigandine with higher piercing protection.
+#define ARMOR_DRAGONHIDE list("blunt" = DR_HEAVY, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_LIGHT, "fire" = DR_SUPER, "acid" = DR_NONE)
+#define ARMOR_BRIGANDINE list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_NONE, "acid" = DR_NONE)
+#define ARMOR_BATHYHIDE list("blunt" = DR_SUPER, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_HEAVY, "fire" = DR_NONE, "acid" = DR_NONE)
 
 // ---- Lightning adaptation (Fulgurmancy Bolt of Lightning) ----
 // Gates the immobilize/clickcd/lightningstruck CC stack so a target can't be perma-locked

--- a/modular_azurepeak/code/modules/spells/magi2/spells/battlewardry/_rune_ward_structure.dm
+++ b/modular_azurepeak/code/modules/spells/magi2/spells/battlewardry/_rune_ward_structure.dm
@@ -125,7 +125,7 @@
 	var/mob/living/carbon/human/owner = owner_ref?.resolve()
 	if(ishuman(owner) && ishuman(L))
 		arcyne_strike(owner, L, null, rune_damage, BODY_ZONE_CHEST, \
-			BCLASS_STAB, armor_penetration = 30, spell_name = "Force Rune", \
+			BCLASS_STAB, armor_penetration = PEN_MEDIUM, spell_name = "Force Rune", \
 			damage_type = BRUTE, skip_animation = TRUE)
 	else
 		L.adjustBruteLoss(rune_damage)

--- a/modular_azurepeak/code/modules/spells/magi2/spells/ferramancy/arcyne_lance.dm
+++ b/modular_azurepeak/code/modules/spells/magi2/spells/ferramancy/arcyne_lance.dm
@@ -44,7 +44,7 @@
 	npc_damage_mult = 1.5
 	nodamage = FALSE
 	speed = MAGE_PROJ_MEDIUM
-	armor_penetration = 10
+	armor_penetration = PEN_LIGHT
 	movement_type = UNSTOPPABLE
 	range = SPELL_RANGE_PROJECTILE
 	flag = "piercing"

--- a/modular_azurepeak/code/modules/spells/magi2/spells/ferramancy/stygian_efflorescence.dm
+++ b/modular_azurepeak/code/modules/spells/magi2/spells/ferramancy/stygian_efflorescence.dm
@@ -61,7 +61,7 @@
 	damage = 34
 	damage_type = BRUTE
 	woundclass = BCLASS_STAB
-	armor_penetration = 10
+	armor_penetration = PEN_LIGHT
 	npc_damage_mult = 1.5
 	speed = MAGE_PROJ_SLOW
 	accuracy = 65

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -73,7 +73,7 @@
 	// Bone is a physical projectile - route it through real armor instead of the
 	// magic flag (which no armor protects against), so plate actually stops it.
 	flag = "piercing"
-	armor_penetration = 30
+	armor_penetration = PEN_MEDIUM
 	nodamage = FALSE
 	var/embed_prob = 10
 	npc_damage_mult = 1.5

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/orc.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/orc.dm
@@ -69,7 +69,7 @@
 	ai_controller = /datum/ai_controller/elite_orc
 	melee_damage_lower = 30
 	melee_damage_upper = 35
-	armor_penetration = 35
+	armor_penetration = PEN_MEDIUM
 	maxHealth = ORC_HEALTH * 2 //TWICE THE ORC
 	health = ORC_HEALTH * 2
 	loot = list(/obj/effect/mob_spawn/human/orc/corpse/orcmarauder,
@@ -93,7 +93,7 @@
 	ai_controller = /datum/ai_controller/elite_orc
 	melee_damage_lower = 40
 	melee_damage_upper = 50
-	armor_penetration = 40
+	armor_penetration = PEN_MEDIUM
 	maxHealth = ORC_HEALTH * 5
 	health = ORC_HEALTH * 5
 	loot = list(/obj/effect/mob_spawn/human/orc/corpse/orcravager,
@@ -108,7 +108,7 @@
 	base_intents = list(/datum/intent/spear/thrust/orcthrust)
 	melee_damage_lower = 30
 	melee_damage_upper = 30
-	armor_penetration = 35
+	armor_penetration = PEN_MEDIUM
 	attack_verb_continuous = list("stabs", "slashes", "skewers")
 	attack_verb_simple = "stab"
 	attack_sound = 'sound/blank.ogg'

--- a/modular_helmsguard/code/game/objects/items/weapons/ranged/arquebus.dm
+++ b/modular_helmsguard/code/game/objects/items/weapons/ranged/arquebus.dm
@@ -7,7 +7,7 @@
 	item_state = "arquebus"
 	force = 10
 	force_wielded = 15
-	possible_item_intents = list(/datum/intent/mace/strike/wood/gunbash)
+	possible_item_intents = list(/datum/intent/mace/strike/wood)
 	gripped_intents = list(/datum/intent/shoot/arquebus, /datum/intent/arc/arquebus, INTENT_GENERIC)
 	internal_magazine = TRUE
 	mag_type = /obj/item/ammo_box/magazine/internal/arquebus
@@ -79,11 +79,6 @@
 		else
 			to_chat(user, "<span class='warning'>There is no rod stowed in the [src]!</span>")
 
-
-// Firearms borrow the wooden-club bash for pistol-whipping, but a gun lacks a
-// mace's mass to drive force through plate, so it must not inherit blunt chipping.
-/datum/intent/mace/strike/wood/gunbash
-	blunt_chipping = FALSE
 
 /datum/intent/shoot/arquebus
 	chargedrain = 0
@@ -267,7 +262,7 @@
 	icon_state = "pistol"
 	item_state = "pistol"
 	force = 10
-	possible_item_intents = list(/datum/intent/shoot/arquebus_pistol, /datum/intent/arc/arquebus_pistol, /datum/intent/mace/strike/wood/gunbash)
+	possible_item_intents = list(/datum/intent/shoot/arquebus_pistol, /datum/intent/arc/arquebus_pistol, /datum/intent/mace/strike/wood)
 	internal_magazine = TRUE
 	mag_type = /obj/item/ammo_box/magazine/internal/arquebus
 	wlength = WLENGTH_SHORT

--- a/modular_helmsguard/code/game/objects/items/weapons/ranged/handgonne.dm
+++ b/modular_helmsguard/code/game/objects/items/weapons/ranged/handgonne.dm
@@ -7,7 +7,7 @@
 	item_state = "handgonne"
 	force = 10
 	force_wielded = 15
-	possible_item_intents = list(/datum/intent/mace/strike/wood/gunbash)
+	possible_item_intents = list(/datum/intent/mace/strike/wood)
 	gripped_intents = list(/datum/intent/shoot/arquebus, /datum/intent/arc/arquebus, INTENT_GENERIC)
 	internal_magazine = TRUE
 	mag_type = /obj/item/ammo_box/magazine/internal/arquebus

--- a/modular_helmsguard/code/game/objects/structures/catapult.dm
+++ b/modular_helmsguard/code/game/objects/structures/catapult.dm
@@ -313,7 +313,7 @@
 	damage = 15
 	range = 8
 	pass_flags = PASSTABLE | PASSGRILLE
-	armor_penetration = 15
+	armor_penetration = PEN_LIGHT
 	damage_type = BRUTE
 	nodamage = FALSE
 	embedchance = 20

--- a/modular_helmsguard/code/modules/mobs/farm/horse.dm
+++ b/modular_helmsguard/code/modules/mobs/farm/horse.dm
@@ -396,7 +396,7 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = "punch_hard"
 	chargetime = 0
-	penfactor = 10
+	penfactor = PEN_NONE
 	swingdelay = 0
 	candodge = TRUE
 	canparry = TRUE

--- a/modular_helmsguard/code/modules/mobs/farm/mimic.dm
+++ b/modular_helmsguard/code/modules/mobs/farm/mimic.dm
@@ -138,7 +138,7 @@
 	blade_class = BCLASS_CUT
 	hitsound = "genchop"
 	chargetime = 20
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	swingdelay = 3
 	candodge = TRUE
 	canparry = TRUE

--- a/modular_helmsguard/code/modules/mobs/farm/wraiths.dm
+++ b/modular_helmsguard/code/modules/mobs/farm/wraiths.dm
@@ -243,5 +243,5 @@
 	animname = "cut"
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	chargetime = 0
-	penfactor = 10
+	penfactor = PEN_LIGHT
 	swingdelay = 8

--- a/modular_stonehedge/code/modules/clothing/rogueclothes/hats.dm
+++ b/modular_stonehedge/code/modules/clothing/rogueclothes/hats.dm
@@ -14,7 +14,7 @@
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES|NECK
 	//Something between leather and metal helmet, worse than metal helmet by far.
-	armor = list("blunt" = 70, "slash" = 65, "stab" = 60, "piercing" = 20, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST)
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
@@ -28,7 +28,7 @@
 	item_state = "studhood"
 	max_integrity = 280
 	//closer to metal helmet but still quite behind, same blunt resist of hardened leather helmet though.
-	armor = list("blunt" = 90, "slash" = 80, "stab" = 70, "piercing" = 20, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = DR_ULTRA, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_LIGHT, "fire" = DR_NONE, "acid" = DR_NONE)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT, BCLASS_TWIST, BCLASS_CHOP, BCLASS_SMASH) //studded armor values with stab prot too
 
 /obj/item/clothing/head/roguetown/helmet/leather/armorhood/AdjustClothes(mob/user)


### PR DESCRIPTION
Complete the armor rework onto AP's tier model (PEN_/DBLOCK_/DR_), replacing the old 0-100 percentage penetration everywhere it feeds the mob/player armor check.

- Convert all melee weapon penfactors to PEN_* tiers (mirror AP per weapon, bucket ES-only) and all ammo/thrown/firearm/magic projectile pens to tiers.
- Convert every hostile mob/NPC attack pen (werewolf, gnoll, trolls, bosses, wildshapes, dragon, orcs, deepone, magi2 spells, etc.) across code/ and modular_*; leave object-integrity pens (0-100) untouched.
- Remove the blunt chipping mechanic entirely (defines, vars, examine, logic, weapon flags, orphaned intent subtypes repointed).
- Fix racial armor sign bug: positive race armor now reduces damage instead of adding it (apply_damage + wound calc).
- Give worn armor fire resistance (fabric/leather DR_MEDIUM, metal DR_LIGHT), mirroring AP PR #7154; cloth and special sets left as-is.
- Retune colorgrade_rating() from 0-100 bands to tier bands so the armor absorption examine stops reading all F.




