### PR TITLE
gnoll hunting feedback/combat role adjusted

### DIFF
--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
@@ -32,15 +32,11 @@
 /proc/get_gnoll_tracking_combat_roles()
 	var/static/list/combat_roles = list(
 		"Orthodoxist" = TRUE,
-		"Absolver" = TRUE,
 		"Templar" = TRUE,
 		"Sergeant" = TRUE,
 		"Man at Arms" = TRUE,
 		"Knight" = TRUE,
-		"Squire" = TRUE,
-		"Mercenary" = TRUE,
 		"Warden" = TRUE,
-		"Acolyte" = TRUE,
 		"Vanguard" = TRUE,
 		"City Guard" = TRUE,
 		"Bandit" = TRUE,

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -74,9 +74,10 @@
 			continue
 		if(human.has_flaw(/datum/charflaw/hunted))
 			add_target_to_list(human, hunted_targets, name_counts)
+			to_chat(user, span_warning("I catch the sent of Graggers hunted! These are my true pray."))
 		else if(human.job in combat_roles)
 			add_target_to_list(human, combat_targets, name_counts)
-			to_chat(user, span_warning("None of Graggers hunted lurk these lands. I shall follow the scent of combatants in their stead"))
+			to_chat(user, span_warning("None of Graggers hunted lurk these lands. I shall follow the scent of combatants in their stead."))
 
 	var/list/possible_targets = length(hunted_targets) ? hunted_targets : combat_targets
 

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -76,6 +76,7 @@
 			add_target_to_list(human, hunted_targets, name_counts)
 		else if(human.job in combat_roles)
 			add_target_to_list(human, combat_targets, name_counts)
+			to_chat(user, span_warning("None of Graggers hunted lurk these lands. I shall follow the scent of combatants in their stead"))
 
 	var/list/possible_targets = length(hunted_targets) ? hunted_targets : combat_targets
 


### PR DESCRIPTION
## About The Pull Request
Removes Absolver, squire, Acolyte and mercs from the list of ''combat roles'' for gnolls to hunt.

Offers feedback to the gnoll casting so they know if they are viewing a hunted list or a list of combat rolls.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles. Tested that the messages appear with both a hunted and non-hunted. I can't confirm the interaction when there is BOTH combat roles and vice hunted so thats getting tested live.

 Otherwise we testing on live.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Every gnoll player I've spoken to would prefer to know if they are dealing with people that signed up to get hunted or just happened to unknowingly pick a role that makes them on the list. This gives gnolls feedback on such. So they know if their targets are hyper valid or just some person not worthy of fraggeriting. This only offers the means to track those roles. Not vaild initiation on them.

As for the role adjustments. Acolytes are not combatants, Absolver is   literally a pacifist, Squires are a trainee role and frankly I dont think mercs dangerous enough on avg to be thrown in the lot. (could be handled class by class I guess but im lazy)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
